### PR TITLE
fix(search): repair every search tool — six independent bugs

### DIFF
--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -9,7 +9,9 @@
  *
  * Pagination note: Thunderbird returns a `MessageList` with an opaque `id` plus a
  * first page, and `messages.continueList(id)` walks it. We surface that id as our
- * `cursor` unchanged.
+ * `cursor` — except when a caller's `limit` lands mid-page, where the cursor also
+ * has to stand for the part of the page already fetched but not handed out. See
+ * `collectPage`.
  */
 
 {
@@ -60,16 +62,66 @@
     return listOrId;
   }
 
-  /** Walk a MessageList to at most `limit` items, returning a continuation cursor. */
-  async function takePage(list, limit) {
+  /** The tail of a page we fetched but have not handed out yet, by cursor.
+   *
+   *  Thunderbird chooses the page size and we cannot always override it —
+   *  `messages.list` takes no `messagesPerPage` at all. So whenever `limit` is
+   *  smaller than the page, stopping mid-page and returning the list id stranded
+   *  the remainder: `continueList` advances to the *next* page, and those
+   *  messages became unreachable. Measured on a 586-message folder, paging 3 at a
+   *  time skipped 9 of every 12. Hold the tail against the cursor instead. */
+  const carriedOver = new Map();
+  const MAX_CARRIED = 32;
+  let tailSequence = 0;
+
+  /** Park `rest` and return the cursor that will serve it.
+   *
+   *  `listId` is null on a final page — there is nothing left to continue from,
+   *  so mint a key rather than tell the caller the walk is over with messages
+   *  still in hand. */
+  function carryOver(listId, rest) {
+    if (carriedOver.size >= MAX_CARRIED) {
+      // Insertion-ordered: drop the least recently parked. An abandoned search
+      // must not pin a page for the life of the session.
+      carriedOver.delete(carriedOver.keys().next().value);
+    }
+    const key = listId || `tail-${(tailSequence += 1)}`;
+    carriedOver.set(key, { messages: rest, listId });
+    return key;
+  }
+
+  /** Fetch up to `limit` messages, resuming from `cursor` when there is one. */
+  async function collectPage(cursor, start, limit) {
     const messages = [];
-    let current = await asMessageList(list);
+    let current;
+
+    if (cursor && carriedOver.has(cursor)) {
+      const held = carriedOver.get(cursor);
+      carriedOver.delete(cursor);
+      current = { messages: held.messages, id: held.listId };
+    } else if (cursor) {
+      try {
+        current = await browser.messages.continueList(cursor);
+      } catch (ex) {
+        throw tbxError.usage(
+          "that cursor has expired (Thunderbird drops message lists when it restarts " +
+            "or after a timeout) — re-run the search without a cursor"
+        );
+      }
+    } else {
+      current = await asMessageList(await start());
+    }
+
     while (current) {
-      for (const message of current.messages || []) {
-        messages.push(header(message));
+      const page = current.messages || [];
+      for (let index = 0; index < page.length; index += 1) {
+        messages.push(header(page[index]));
         if (messages.length >= limit) {
-          // Keep the list alive so the caller can continue from it.
-          return { messages, cursor: current.id || null };
+          const rest = page.slice(index + 1);
+          return {
+            messages,
+            cursor: rest.length ? carryOver(current.id, rest) : current.id || null,
+          };
         }
       }
       if (!current.id) {
@@ -81,20 +133,6 @@
       }
     }
     return { messages, cursor: null };
-  }
-
-  async function resumeOrStart(cursor, start) {
-    if (cursor) {
-      try {
-        return await browser.messages.continueList(cursor);
-      } catch (ex) {
-        throw tbxError.usage(
-          "that cursor has expired (Thunderbird drops message lists when it restarts " +
-            "or after a timeout) — re-run the search without a cursor"
-        );
-      }
-    }
-    return start();
   }
 
   // --------------------------------------------------------------------- query
@@ -160,8 +198,7 @@
     query.returnMessageListId = true;
     query.messagesPerPage = Math.min(Math.max(limit, 10), 100);
 
-    const list = await resumeOrStart(params.cursor, () => browser.messages.query(query));
-    const paged = await takePage(list, limit);
+    const paged = await collectPage(params.cursor, () => browser.messages.query(query), limit);
     const result = {
       messages: paged.messages,
       cursor: paged.cursor,
@@ -182,13 +219,15 @@
   tbxRegistry.define("messages.list", async (params) => {
     const folderId = tbxUtil.need(params, "folderId", "string");
     const limit = params.limit || DEFAULT_LIMIT;
-    const list = await resumeOrStart(params.cursor, () =>
-      browser.messages.list(folderId, {
-        sortType: params.sortType || "date",
-        sortOrder: params.sortOrder || "descending",
-      })
+    const paged = await collectPage(
+      params.cursor,
+      () =>
+        browser.messages.list(folderId, {
+          sortType: params.sortType || "date",
+          sortOrder: params.sortOrder || "descending",
+        }),
+      limit
     );
-    const paged = await takePage(list, limit);
     return { messages: paged.messages, cursor: paged.cursor, folderId };
   });
 

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -44,10 +44,26 @@
     };
   }
 
+  /** Resolve whatever `query`/`list` handed back into an actual MessageList.
+   *
+   *  `messages.query({returnMessageListId: true})` does not return a MessageList:
+   *  its schema return type is `MessageList | string`, and with the flag set
+   *  MessageQuery.startSearch() returns `this.messageList.id` — a bare string —
+   *  so the caller can hold the list id before the first page has filled. Walking
+   *  that string as if it were a page yielded no `.messages` and no `.id`, so
+   *  every messages.query answered `{messages: [], cursor: null}` no matter what
+   *  was asked. Trade the id for its first page here. */
+  async function asMessageList(listOrId) {
+    if (typeof listOrId === "string") {
+      return browser.messages.continueList(listOrId);
+    }
+    return listOrId;
+  }
+
   /** Walk a MessageList to at most `limit` items, returning a continuation cursor. */
   async function takePage(list, limit) {
     const messages = [];
-    let current = list;
+    let current = await asMessageList(list);
     while (current) {
       for (const message of current.messages || []) {
         messages.push(header(message));
@@ -83,6 +99,60 @@
 
   // --------------------------------------------------------------------- query
 
+  function collectFolderIds(folders, out) {
+    for (const folder of folders || []) {
+      if (folder.id) {
+        out.push(folder.id);
+      }
+      collectFolderIds(folder.subFolders, out);
+    }
+    return out;
+  }
+
+  /** Which folders the query covered, so an empty result can be interpreted.
+   *
+   *  Thunderbird does not report this back, but its scoping rule is fixed
+   *  (ExtensionMessages.sys.mjs::MessageQuery.startSearch): `folderId` scopes to
+   *  those folders, plus their descendants when `includeSubFolders` is set; with
+   *  no `folderId` every folder of the named accounts — or of every account — is
+   *  searched. Mirror that rule rather than guess at it. An unscoped search names
+   *  the accounts instead of enumerating thousands of folder ids. */
+  function accountIdOf(folderId) {
+    const cut = String(folderId).indexOf(":/");
+    return cut > 0 ? String(folderId).slice(0, cut) : null;
+  }
+
+  async function searchedScope(query) {
+    const named = query.accountId ? [].concat(query.accountId) : null;
+    if (query.folderId) {
+      // With both set Thunderbird intersects them: a folder outside the named
+      // accounts is dropped, not searched.
+      const roots = [].concat(query.folderId).filter(
+        (id) => !named || named.includes(accountIdOf(id))
+      );
+      const folderIds = roots.slice();
+      if (query.includeSubFolders) {
+        for (const root of roots) {
+          const children = await browser.folders.getSubFolders(root, true).catch(() => []);
+          collectFolderIds(children, folderIds);
+        }
+      }
+      return {
+        scope: "folders",
+        accountIds: [...new Set(roots.map(accountIdOf).filter(Boolean))],
+        folderIds,
+        includeSubFolders: Boolean(query.includeSubFolders),
+      };
+    }
+    const accountIds =
+      named || ((await browser.accounts.list(false).catch(() => [])) || []).map((a) => a.id);
+    return {
+      scope: named ? "accounts" : "all-accounts",
+      accountIds,
+      includeSubFolders: true,
+    };
+  }
+
   tbxRegistry.define("messages.query", async (params) => {
     const limit = params.limit || DEFAULT_LIMIT;
     const query = Object.assign({}, params.query || {});
@@ -92,7 +162,11 @@
 
     const list = await resumeOrStart(params.cursor, () => browser.messages.query(query));
     const paged = await takePage(list, limit);
-    const result = { messages: paged.messages, cursor: paged.cursor };
+    const result = {
+      messages: paged.messages,
+      cursor: paged.cursor,
+      searchedFolders: await searchedScope(query),
+    };
     if (query.fullText && browser.tbx) {
       // Worth saying: fullText only sees what the global indexer has processed.
       const indexed = await browser.tbx.globalIndexEnabled().catch(() => null);

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -230,11 +230,14 @@
     query.messagesPerPage = Math.min(Math.max(limit, 10), 100);
 
     const paged = await collectPage(params.cursor, () => browser.messages.query(query), limit);
-    const result = {
-      messages: paged.messages,
-      cursor: paged.cursor,
-      searchedFolders: await searchedScope(query),
-    };
+    const result = { messages: paged.messages, cursor: paged.cursor };
+    // Only when the walk starts. The scope cannot change mid-walk, and working it
+    // out means enumerating an account's subfolders — which on a large IMAP
+    // account is the most expensive thing this handler does. Paying that on every
+    // page to re-send a constant is waste the caller cannot even see.
+    if (!params.cursor) {
+      result.searchedFolders = await searchedScope(query);
+    }
     if (query.fullText && browser.tbx) {
       // Worth saying: fullText only sees what the global indexer has processed.
       const indexed = await browser.tbx.globalIndexEnabled().catch(() => null);

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -72,7 +72,31 @@
    *  time skipped 9 of every 12. Hold the tail against the cursor instead. */
   const carriedOver = new Map();
   const MAX_CARRIED = 32;
+  /** Cursors whose tail we dropped, so a resume can say so instead of guessing. */
+  const droppedTails = new Set();
+  const MAX_DROPPED = 256;
   let tailSequence = 0;
+
+  /** Forget the least recently parked tail, and make its cursor unusable.
+   *
+   *  Eviction alone would reintroduce the very bug this cache exists to fix: the
+   *  cursor is usually Thunderbird's own list id, so a resume would miss the
+   *  cache, fall through to `continueList`, and cheerfully return the *next*
+   *  page — skipping the tail we just dropped, silently. Abort the underlying
+   *  list so that path fails loudly, and remember the key so the failure can name
+   *  its real cause rather than blaming a restart. */
+  function evictOldest() {
+    const key = carriedOver.keys().next().value;
+    const held = carriedOver.get(key);
+    carriedOver.delete(key);
+    if (held && held.listId) {
+      browser.messages.abortList(held.listId).catch(() => {});
+    }
+    if (droppedTails.size >= MAX_DROPPED) {
+      droppedTails.delete(droppedTails.values().next().value);
+    }
+    droppedTails.add(key);
+  }
 
   /** Park `rest` and return the cursor that will serve it.
    *
@@ -81,11 +105,11 @@
    *  still in hand. */
   function carryOver(listId, rest) {
     if (carriedOver.size >= MAX_CARRIED) {
-      // Insertion-ordered: drop the least recently parked. An abandoned search
-      // must not pin a page for the life of the session.
-      carriedOver.delete(carriedOver.keys().next().value);
+      evictOldest();
     }
     const key = listId || `tail-${(tailSequence += 1)}`;
+    // Reusing a key we previously dropped: it is live again.
+    droppedTails.delete(key);
     carriedOver.set(key, { messages: rest, listId });
     return key;
   }
@@ -99,6 +123,13 @@
       const held = carriedOver.get(cursor);
       carriedOver.delete(cursor);
       current = { messages: held.messages, id: held.listId };
+    } else if (cursor && droppedTails.has(cursor)) {
+      throw tbxError.usage(
+        `that cursor was dropped: more than ${MAX_CARRIED} searches were left ` +
+          "part-read, and this was the least recently used. Resuming it would skip " +
+          "messages, so re-run the search without a cursor — and page one search to " +
+          "the end before starting the next."
+      );
     } else if (cursor) {
       try {
         current = await browser.messages.continueList(cursor);

--- a/addon/background/handlers/privileged.js
+++ b/addon/background/handlers/privileged.js
@@ -56,9 +56,18 @@
     try {
       return await browser.tbx.invoke(bare, params);
     } catch (ex) {
-      // Errors thrown inside the experiment arrive as plain Error objects with the
-      // message intact; re-tag them so the taxonomy survives the hop.
-      const message = String(ex.message || ex);
+      // The privileged half tags its errors `tbx:<kind>:<message>` because
+      // ExtensionCommon.normalizeError rebuilds the Error on the way across and
+      // drops every property but the message. Read the tag when it is there.
+      const raw = String(ex.message || ex);
+      const tagged = /^tbx:(usage|blocked|unsupported|thunderbird):([\s\S]*)$/.exec(raw);
+      if (tagged) {
+        const [, kind, message] = tagged;
+        const make = tbxError[kind] || tbxError.thunderbird;
+        throw make(message);
+      }
+      // Untagged: something outside invoke() threw. Guess from the text, as before.
+      const message = raw;
       if (/ is required|must be|unknown privileged method|not an? /.test(message)) {
         throw tbxError.usage(message);
       }

--- a/addon/background/handlers/privileged.js
+++ b/addon/background/handlers/privileged.js
@@ -56,15 +56,26 @@
     try {
       return await browser.tbx.invoke(bare, params);
     } catch (ex) {
-      // The privileged half tags its errors `tbx:<kind>:<message>` because
-      // ExtensionCommon.normalizeError rebuilds the Error on the way across and
-      // drops every property but the message. Read the tag when it is there.
+      // The privileged half packs `tbx:` + a JSON payload into the message,
+      // because ExtensionCommon.normalizeError rebuilds the Error on the way
+      // across and drops every property but the message. Unpack it when present:
+      // `needs` has to arrive as data, since PROTOCOL.md has clients read it to
+      // learn what would unblock the call.
       const raw = String(ex.message || ex);
-      const tagged = /^tbx:(usage|blocked|unsupported|thunderbird):([\s\S]*)$/.exec(raw);
-      if (tagged) {
-        const [, kind, message] = tagged;
-        const make = tbxError[kind] || tbxError.thunderbird;
-        throw make(message);
+      if (raw.startsWith("tbx:")) {
+        let payload = null;
+        try {
+          payload = JSON.parse(raw.slice(4));
+        } catch (parseError) {
+          payload = null;
+        }
+        if (payload && typeof payload.message === "string") {
+          if (payload.kind === "blocked") {
+            throw tbxError.blocked(payload.message, payload.needs);
+          }
+          const make = tbxError[payload.kind] || tbxError.thunderbird;
+          throw make(payload.message);
+        }
       }
       // Untagged: something outside invoke() threw. Guess from the text, as before.
       const message = raw;

--- a/addon/background/registry.js
+++ b/addon/background/registry.js
@@ -30,7 +30,10 @@ var tbxError = {
     const payload = {
       kind: ex.tbxKind || "thunderbird",
       message: String(ex.message || ex),
-      code: ex.code || ex.name || null,
+      // `name` is worth carrying when it says something — ReferenceError,
+      // TypeError, an nsresult — but a bare "Error" is every JS error ever
+      // thrown, and it rendered as a spurious `[Error]` tag on the message.
+      code: ex.code || (ex.name && ex.name !== "Error" ? ex.name : null),
     };
     if (ex.needs) {
       payload.needs = Array.isArray(ex.needs) ? ex.needs : [ex.needs];

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -22,6 +22,21 @@
 
 "use strict";
 
+/* ------------------------------------------------------------------- timers */
+
+/* Timers are not globals here. `setTimeout` is a DOM global, and the ext-*.js
+ * sandbox is built with `wantGlobalProperties: ["ChromeUtils"]` and an explicit
+ * Object.assign of Services/Cc/Ci/Cu/Cr/IOUtils/PathUtils/XPCOMUtils — no timer
+ * functions (ExtensionCommon.sys.mjs::_createExtGlobal, verified on Thunderbird
+ * 153). Calling setTimeout threw ReferenceError inside every H.withTimeout(),
+ * which rejected the deadline promise before the work it guarded had started:
+ * gloda.search and gloda.conversation failed outright, gloda.stats swallowed it
+ * into `indexedMessages: null`, and calendar/filters/junk lost their deadlines
+ * too. Import the real ones — the module is the same one the DOM globals wrap. */
+const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
+  "resource://gre/modules/Timer.sys.mjs"
+);
+
 /* ------------------------------------------------------------------ modules */
 
 /** Module URLs as they exist on Thunderbird 128–153. Resolution is lazy so a
@@ -83,6 +98,37 @@ function needMod(key) {
 }
 
 /* ------------------------------------------------------------------ helpers */
+
+/** Prefix that carries an error's kind across the API boundary intact. */
+const TBX_ERROR_TAG = "tbx:";
+
+/** Re-throw an error so its message survives the experiment API boundary.
+ *
+ *  ExtensionCommon.sys.mjs::normalizeError keeps a message only for a plain
+ *  object, an ExtensionError, or an error whose principal the extension
+ *  subsumes. A `new Error` raised in this system-principal sandbox is none of
+ *  those, so every failure here reached the caller as the generic
+ *  "An unexpected error occurred" with the real text left in the Error Console.
+ *  That is how a bare `setTimeout is not defined` presented as an unexplained
+ *  tool failure. Wrap in ExtensionError, and keep the kind in a prefix the
+ *  background page strips — normalizeError rebuilds the Error and drops any
+ *  properties we might otherwise have hung on it. */
+function wireError(error) {
+  const kind = (error && error.tbxKind) || "thunderbird";
+  const message = String((error && error.message) || error || "unknown error");
+  const needs = error && error.needs ? ` (requires: ${[].concat(error.needs).join(", ")})` : "";
+  const tagged = `${TBX_ERROR_TAG}${kind}:${message}${needs}`;
+  try {
+    const { ExtensionError } = ChromeUtils.importESModule(
+      "resource://gre/modules/ExtensionUtils.sys.mjs"
+    );
+    return new ExtensionError(tagged);
+  } catch (ex) {
+    // Without ExtensionError the message is lost anyway; a plain object is the
+    // other shape normalizeError preserves.
+    return { message: tagged };
+  }
+}
 
 const H = {
   usage(message) {
@@ -220,14 +266,21 @@ const H = {
     }
   },
 
-  /** Wrap a callback-style Thunderbird API as a promise with a deadline. */
+  /** Wrap a callback-style Thunderbird API as a promise with a deadline.
+   *
+   *  The timer is cleared once the race settles. Without that, a 45s search
+   *  deadline keeps a live timer for 45s after the search has already answered,
+   *  which on a busy session is a slow drip of pending timers holding closures. */
   withTimeout(promise, ms, what) {
-    return Promise.race([
-      promise,
-      new Promise((_resolve, reject) =>
-        setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms)
-      ),
-    ]);
+    let timer = null;
+    const deadline = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms);
+    });
+    return Promise.race([promise, deadline]).finally(() => {
+      if (timer !== null) {
+        clearTimeout(timer);
+      }
+    });
   },
 };
 
@@ -464,9 +517,13 @@ this.tbx = class extends ExtensionAPI {
           const handler = TBX_MODULES[method];
           if (!handler) {
             const known = Object.keys(TBX_MODULES).sort().join(", ");
-            throw H.usage(`unknown privileged method ${method} (known: ${known})`);
+            throw wireError(H.usage(`unknown privileged method ${method} (known: ${known})`));
           }
-          return handler(params || {});
+          try {
+            return await handler(params || {});
+          } catch (ex) {
+            throw wireError(ex);
+          }
         },
       },
     };

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -99,7 +99,7 @@ function needMod(key) {
 
 /* ------------------------------------------------------------------ helpers */
 
-/** Prefix that carries an error's kind across the API boundary intact. */
+/** Prefix marking a message that carries a JSON error payload, not prose. */
 const TBX_ERROR_TAG = "tbx:";
 
 /** Re-throw an error so its message survives the experiment API boundary.
@@ -110,14 +110,24 @@ const TBX_ERROR_TAG = "tbx:";
  *  those, so every failure here reached the caller as the generic
  *  "An unexpected error occurred" with the real text left in the Error Console.
  *  That is how a bare `setTimeout is not defined` presented as an unexplained
- *  tool failure. Wrap in ExtensionError, and keep the kind in a prefix the
- *  background page strips — normalizeError rebuilds the Error and drops any
- *  properties we might otherwise have hung on it. */
+ *  tool failure. Wrap in ExtensionError, and carry the taxonomy as JSON inside
+ *  the message — normalizeError rebuilds the Error and drops every property but
+ *  `message`, so the message is the only channel there is. */
 function wireError(error) {
-  const kind = (error && error.tbxKind) || "thunderbird";
-  const message = String((error && error.message) || error || "unknown error");
-  const needs = error && error.needs ? ` (requires: ${[].concat(error.needs).join(", ")})` : "";
-  const tagged = `${TBX_ERROR_TAG}${kind}:${message}${needs}`;
+  const payload = {
+    kind: (error && error.tbxKind) || "thunderbird",
+    message: String((error && error.message) || error || "unknown error"),
+  };
+  // `needs` is protocol, not prose: PROTOCOL.md promises a `blocked` error
+  // "lists what would unblock it", and callers pass a real remedy — files.write
+  // answers "overwrite=true, or a different filename". Flattened into the
+  // message it stops being something a client can act on programmatically, and
+  // the Python layer appends its own "(requires: …)" from the structured field,
+  // so prose here would read twice. Keep it a field.
+  if (error && error.needs) {
+    payload.needs = [].concat(error.needs);
+  }
+  const tagged = TBX_ERROR_TAG + JSON.stringify(payload);
   try {
     const { ExtensionError } = ChromeUtils.importESModule(
       "resource://gre/modules/ExtensionUtils.sys.mjs"

--- a/addon/experiment/modules/gloda.js
+++ b/addon/experiment/modules/gloda.js
@@ -448,6 +448,11 @@ TBX_MODULE_NAMES.push("gloda");
       Math.max((offset + limit) * (inScope ? 10 : 3), 50),
       MAX_RETRIEVE
     );
+    /* Ask the index for one row more than we mean to use. A LIMIT that comes back
+     * exactly full cannot tell "this is everything" from "the cap cut it off", so
+     * testing `length >= retrieve` called a complete result set truncated — which
+     * suppressed the exact total the caller could otherwise have had. One spare
+     * row answers the question outright. */
     const messages = await collect(
       (listener) => {
         // What getCollection() does, minus its pref-driven retrieval limit: the
@@ -455,16 +460,20 @@ TBX_MODULE_NAMES.push("gloda");
         // ours nests inside it.
         searcher.listener = listener;
         searcher.query = searcher.buildFulltextQuery();
-        searcher.query.limit(retrieve);
+        searcher.query.limit(retrieve + 1);
         searcher.collection = searcher.query.getCollection(searcher, null);
       },
       "gloda search",
       SEARCH_TIMEOUT_MS
     );
+    const truncated = messages.length > retrieve;
+    // Drop the probe row so it cannot reach the caller or skew the count.
+    const considered = truncated ? messages.slice(0, retrieve) : messages;
 
-    // searcher.scores accumulates in the order items were handed to us.
+    // searcher.scores accumulates in the order items were handed to us, so it
+    // stays aligned as long as we slice from the front.
     const scores = searcher.scores || [];
-    let hits = messages.map((message, index) => hit(message, scores[index]));
+    let hits = considered.map((message, index) => hit(message, scores[index]));
     if (inScope) {
       hits = hits.filter(inScope);
     }
@@ -475,9 +484,9 @@ TBX_MODULE_NAMES.push("gloda");
       query,
       hits: hits.slice(offset, offset + limit),
       matched: hits.length,
-      retrieved: messages.length,
+      retrieved: considered.length,
       // The ranking only ordered what we retrieved; a deeper page may reorder.
-      truncated: messages.length >= retrieve,
+      truncated,
       indexEnabled: enabled,
     };
     if (unmatchable.length) {

--- a/addon/experiment/modules/gloda.js
+++ b/addon/experiment/modules/gloda.js
@@ -130,29 +130,85 @@ TBX_MODULE_NAMES.push("gloda");
     }
   }
 
-  /** Accept a WebExtension folder id or a raw folder URI; gloda speaks URIs. */
-  function folderRefToUri(ref) {
-    const text = String(ref).trim();
-    if (text.includes("://")) {
-      return text;
+  /** The account keys this profile actually has. */
+  function accountKeys() {
+    const keys = new Set();
+    try {
+      for (const account of needMod("MailServices").accounts.accounts) {
+        if (account && account.key) {
+          keys.add(account.key);
+        }
+      }
+    } catch (ex) {
+      // An empty set only costs us the "no such account" error message.
     }
+    return keys;
+  }
+
+  /** Split `account7://INBOX` into its account key and folder path.
+   *
+   *  webExtFolderId builds the id as `${key}:/${path}` where `path` itself
+   *  starts with "/", so the separator occupies two characters and the path
+   *  begins at `cut + 2`. Slicing from `cut + 1` — as this did — kept a leading
+   *  slash, producing `imap://…com//INBOX`: a URI that names no folder, so the
+   *  hit filter matched nothing and every folder-scoped search_global came back
+   *  empty, blaming the index. */
+  function splitFolderId(text) {
     const cut = text.indexOf(":/");
     if (cut < 1) {
-      throw H.usage(
-        `${text} is not a folder id — pass one returned by folder_list, or a folder URI`
-      );
+      return null;
     }
+    const key = text.slice(0, cut);
+    return accountKeys().has(key) ? { key, path: text.slice(cut + 2) } : null;
+  }
+
+  /** Decide whether a gloda hit is in the folder the caller named.
+   *
+   *  A caller may name either form and the two are not tellable apart by
+   *  punctuation — a folder id contains "://" exactly like a folder URI does.
+   *  So resolve what we can and compare against both fields a hit carries,
+   *  rather than converting one form into the other and trusting the round trip
+   *  to be byte-exact. */
+  function folderScope(ref) {
+    const text = String(ref).trim();
+    const keys = new Set([text]);
+    const parts = splitFolderId(text);
+    let resolved = Boolean(parts);
     const accounts = extensionAccounts();
-    if (!accounts || !accounts.folderPathToURI) {
-      throw H.unsupported(
-        "this build cannot translate folder ids to folder URIs; pass a folder URI instead"
+    if (parts && accounts && accounts.folderPathToURI) {
+      let uri = null;
+      try {
+        uri = accounts.folderPathToURI(parts.key, parts.path);
+      } catch (ex) {
+        uri = null;
+      }
+      if (uri) {
+        keys.add(uri);
+      }
+    }
+    if (!resolved) {
+      // Not a folder id, so it has to be a URI under one of this profile's
+      // servers. Checking against the real root URIs beats guessing at schemes.
+      try {
+        for (const account of needMod("MailServices").accounts.accounts) {
+          const root = account && account.incomingServer && account.incomingServer.rootFolder;
+          if (root && (text === root.URI || text.startsWith(`${root.URI}/`))) {
+            resolved = true;
+            break;
+          }
+        }
+      } catch (ex) {
+        // Cannot enumerate: accept it rather than refuse a call we cannot judge.
+        resolved = true;
+      }
+    }
+    if (!resolved) {
+      throw H.usage(
+        `${text} names no folder in this profile — pass an id from folder_list, ` +
+          "or a folder URI"
       );
     }
-    const uri = accounts.folderPathToURI(text.slice(0, cut), text.slice(cut + 1));
-    if (!uri) {
-      throw H.usage(`no account with key ${text.slice(0, cut)}`);
-    }
-    return uri;
+    return (entry) => keys.has(entry.folderUri) || keys.has(entry.folderId);
   }
 
   /** Run a gloda query to completion, or give up loudly. */
@@ -181,9 +237,18 @@ TBX_MODULE_NAMES.push("gloda");
   }
 
   function isoDate(value) {
-    if (value instanceof Date) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    /* Duck-type rather than `instanceof Date`. Gloda mints its Date objects in
+     * the shared system global (GlodaDatastore.sys.mjs), while this code runs in
+     * the ext-*.js sandbox — a different realm with a different Date.prototype,
+     * so `instanceof` is false for every one of them. That silently nulled the
+     * date on every hit, which also flattened the conversation ordering that
+     * byDateThenSubject is supposed to provide. */
+    if (typeof value.getTime === "function") {
       const ms = value.getTime();
-      return Number.isFinite(ms) ? value.toISOString() : null;
+      return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
     }
     // Gloda stores PRTime (microseconds) and normally hands back a Date, but
     // conversation bounds have been seen raw.
@@ -262,6 +327,46 @@ TBX_MODULE_NAMES.push("gloda");
     };
   }
 
+  /** Everyone who appears anywhere in the thread, in first-seen order.
+   *
+   *  `involves` is gloda's own union of from/to/cc/bcc. It is an optimization
+   *  attribute and can be absent on a ghost, so fall back to from/to. */
+  function participantsOf(messages) {
+    const seen = new Set();
+    const out = [];
+    const add = (identity) => {
+      const label = identityLabel(identity);
+      if (label && !seen.has(label)) {
+        seen.add(label);
+        out.push(label);
+      }
+    };
+    for (const message of messages) {
+      let involves = null;
+      try {
+        involves = message.involves;
+      } catch (ex) {
+        involves = null;
+      }
+      if (involves && involves.length) {
+        for (const identity of involves) {
+          add(identity);
+        }
+        continue;
+      }
+      try {
+        add(message.from);
+        for (const identity of message.to || []) {
+          add(identity);
+        }
+      } catch (ex) {
+        // A referenced-but-unindexed message carries no identities; the rest
+        // of the thread still names the people involved.
+      }
+    }
+    return out;
+  }
+
   function byDateThenSubject(a, b) {
     const left = a.date || "";
     const right = b.date || "";
@@ -275,6 +380,36 @@ TBX_MODULE_NAMES.push("gloda");
     return Services.prefs.getBoolPref("mailnews.database.global.indexer.enabled", false);
   }
 
+  const NEAR = /^NEAR(\/\d+)?$/;
+
+  /** Whether GlodaMsgSearcher.buildFulltextQuery puts this term into the SQL at
+   *  all — it silently omits anything shorter, which is why a stray "-" or "2"
+   *  costs nothing. */
+  function isEmitted(term) {
+    if (NEAR.test(term)) {
+      return true;
+    }
+    if (term.length >= 3) {
+      return true;
+    }
+    const cjk = (index) => term.charCodeAt(index) >= 0x2000;
+    return (term.length === 1 && cjk(0)) || (term.length === 2 && cjk(0) && cjk(1));
+  }
+
+  /** Whether the term survives tokenization with something the index can match.
+   *  Gloda's tokenizer splits on non-alphanumerics and drops tokens under three
+   *  characters (one for CJK), so "2.0" yields nothing while "e-mail" yields
+   *  "mail". */
+  function isSearchable(term) {
+    if (NEAR.test(term)) {
+      return true;
+    }
+    return String(term)
+      .split(/[^\p{L}\p{N}]+/u)
+      .filter(Boolean)
+      .some((token) => token.length >= 3 || token.charCodeAt(0) >= 0x2000);
+  }
+
   // ------------------------------------------------------------------- search
 
   TBX_MODULES["gloda.search"] = async (params) => {
@@ -284,27 +419,33 @@ TBX_MODULE_NAMES.push("gloda");
       MAX_HITS
     );
     const offset = Number.isInteger(params.offset) && params.offset > 0 ? params.offset : 0;
-    const folderUri = params.folderId ? folderRefToUri(params.folderId) : null;
+    const inScope = params.folderId ? folderScope(params.folderId) : null;
     const Searcher = needMod("GlodaMsgSearcher");
 
-    const searcher = new Searcher(null, query, params.matchAll !== false);
+    const matchAll = params.matchAll !== false;
+    const searcher = new Searcher(null, query, matchAll);
+    const terms = searcher.fulltextTerms || [];
     // The tokenizer drops terms shorter than three characters (one or two for
     // CJK), so a query made only of those silently matches everything or
     // nothing. Say so instead.
-    const usable = (searcher.fulltextTerms || []).some(
-      (term) => term.length >= 3 || term.charCodeAt(0) >= 0x2000
-    );
+    const usable = terms.some(isSearchable);
     if (!usable) {
       throw H.usage(
         `no searchable term in ${JSON.stringify(query)} — the global index needs ` +
           "terms of at least three characters (one for CJK)"
       );
     }
+    /* A term long enough to reach the query but made only of tokens the indexer
+     * throws away — "2.0" splits into "2" and "0" — is a phrase that can never
+     * match, and under AND it takes the whole query down with it. Pasting a
+     * subject line into search_global hits this constantly, and the result was
+     * an empty answer blaming the index. Name the terms instead. */
+    const unmatchable = terms.filter((term) => isEmitted(term) && !isSearchable(term));
 
     /* Gloda has no OFFSET, and a folder filter can only be applied after the
      * fact because the searcher's SQL is fixed. Over-fetch, then slice. */
     const retrieve = Math.min(
-      Math.max((offset + limit) * (folderUri ? 10 : 3), 50),
+      Math.max((offset + limit) * (inScope ? 10 : 3), 50),
       MAX_RETRIEVE
     );
     const messages = await collect(
@@ -324,8 +465,8 @@ TBX_MODULE_NAMES.push("gloda");
     // searcher.scores accumulates in the order items were handed to us.
     const scores = searcher.scores || [];
     let hits = messages.map((message, index) => hit(message, scores[index]));
-    if (folderUri) {
-      hits = hits.filter((entry) => entry.folderUri === folderUri);
+    if (inScope) {
+      hits = hits.filter(inScope);
     }
     hits.sort((a, b) => (b.score || 0) - (a.score || 0) || byDateThenSubject(b, a));
 
@@ -339,12 +480,30 @@ TBX_MODULE_NAMES.push("gloda");
       truncated: messages.length >= retrieve,
       indexEnabled: enabled,
     };
+    if (unmatchable.length) {
+      result.unmatchableTerms = unmatchable;
+    }
     if (!result.hits.length) {
-      result.note = enabled
-        ? "Nothing in the global index matched. Only indexed messages are searchable — " +
-          "check x.gloda.stats, or fall back to mail_search with subject/author filters."
-        : "Thunderbird's global index is disabled, so this search can never match. " +
+      if (!enabled) {
+        result.note =
+          "Thunderbird's global index is disabled, so this search can never match. " +
           "Enable it in Settings > General > Indexing, or use mail_search instead.";
+      } else if (unmatchable.length && matchAll) {
+        result.note =
+          `The index cannot match ${unmatchable.map((t) => JSON.stringify(t)).join(", ")} — ` +
+          "it tokenizes into pieces shorter than three characters, and every term has to " +
+          "match, so this query can never return anything. Drop those words and search " +
+          "again, or use mail_search with a subject filter for an exact substring.";
+      } else if (unmatchable.length) {
+        result.note =
+          `The index cannot match ${unmatchable.map((t) => JSON.stringify(t)).join(", ")}; ` +
+          "the remaining terms matched nothing either. Try mail_search with a subject " +
+          "or author filter.";
+      } else {
+        result.note =
+          "Nothing in the global index matched. Only indexed messages are searchable — " +
+          "check x.gloda.stats, or fall back to mail_search with subject/author filters.";
+      }
     }
     return result;
   };
@@ -429,6 +588,7 @@ TBX_MODULE_NAMES.push("gloda");
     return {
       conversationId: conversation.id,
       subject: conversation.subject,
+      participants: participantsOf(messages),
       oldestDate: isoDate(conversation.oldestMessageDate),
       newestDate: isoDate(conversation.newestMessageDate),
       messages: ordered.slice(0, limit),

--- a/docs/TOOL-REFERENCE.md
+++ b/docs/TOOL-REFERENCE.md
@@ -392,6 +392,10 @@ conversation id you can pass to `search_conversation`. For precise filters
 If this returns nothing unexpectedly, call `search_index_status`: the global
 indexer can be disabled or still catching up.
 
+`truncated` means the ranking only ordered the slice that was retrieved, so
+a deeper page may reorder and `matched` is a floor rather than a total.
+`totalAvailable` appears only when the whole result set came back.
+
 Parameters: **query**, limit, offset, folder_id  
 *(bold means required; `confirm` is the confirmation gate)*
 

--- a/docs/TOOL-REFERENCE.md
+++ b/docs/TOOL-REFERENCE.md
@@ -395,6 +395,8 @@ indexer can be disabled or still catching up.
 `truncated` means the ranking only ordered the slice that was retrieved, so
 a deeper page may reorder and `matched` is a floor rather than a total.
 `totalAvailable` appears only when the whole result set came back.
+`unmatchableTerms`, when present, lists words the index cannot match at
+all — drop them and search again rather than concluding there is nothing.
 
 Parameters: **query**, limit, offset, folder_id  
 *(bold means required; `confirm` is the confirmation gate)*

--- a/docs/TOOL-REFERENCE.md
+++ b/docs/TOOL-REFERENCE.md
@@ -20,6 +20,11 @@ of already-indexed messages; `subject`/`author`/`body` are substring matches
 evaluated per folder. Dates are ISO-8601. Results are summaries — call
 `mail_get` for a body. Continue with `cursor=nextCursor`.
 
+Case matters unevenly, because Thunderbird matches them differently:
+`subject` and `body` are case-sensitive substring tests, while `author` and
+`recipients` are matched as addresses and are not. Searching `subject` for
+a lowercased word finds only the messages that spell it that way.
+
 Parameters: full_text, subject, author, recipients, body, folder_id, account_id, include_subfolders, unread, flagged, junk, has_attachment, tags, tag_mode, from_date, to_date, to_me, from_me, min_size, max_size, limit, cursor  
 *(bold means required; `confirm` is the confirmation gate)*
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,12 @@ filterwarnings = [
   # client that has already dropped support for them.
   "error::mcp.MCPDeprecationWarning",
 ]
+markers = [
+  # Needs a running Thunderbird with the bridge attached. Skips itself when there
+  # is not one, so CI is unaffected; `-m live` runs only these, `-m "not live"`
+  # only the mocked suite.
+  "live: drives a real Thunderbird rather than a recorded bridge",
+]
 
 [tool.ruff]
 line-length = 100

--- a/src/tbmcp/bridge.py
+++ b/src/tbmcp/bridge.py
@@ -191,6 +191,19 @@ class Bridge:
             log.debug("control read loop ended: %s", exc)
             failure = exc
         finally:
+            # Nothing will read a reply once the pump is gone, so retire the
+            # connection here. `_ensure` judges health by the writer alone and
+            # would otherwise post the next request into a socket no one is
+            # reading, then wait out its whole timeout — and do the same for every
+            # call after it, since nothing reopens the connection on its own.
+            #
+            # Only `close()`: that flips `is_closing()`, which is exactly what
+            # `_ensure` tests, and leaves `_teardown` to do the real shutdown with
+            # its `wait_closed()`. Calling `_teardown` from here would deadlock,
+            # since it cancels this task and awaits it.
+            if self._writer is not None:
+                with contextlib.suppress(Exception):
+                    self._writer.close()
             for future in self._pending.values():
                 if not future.done():
                     # A fresh instance per future: sharing one exception across

--- a/src/tbmcp/bridge.py
+++ b/src/tbmcp/bridge.py
@@ -155,6 +155,12 @@ class Bridge:
 
     async def _read_loop(self) -> None:
         assert self._reader is not None
+        # Why the loop ended, when it ended for a reason worth telling the caller.
+        # `read_message` raises TOO_LARGE for an answer that overran the frame
+        # ceiling; flattening that into DISCONNECTED below would put the caller
+        # back where it started, unable to tell an answer that was too big from a
+        # socket that died — and only one of those is worth retrying.
+        failure: BaseException | None = None
         try:
             while True:
                 message = await ipc.read_message(self._reader)
@@ -183,11 +189,16 @@ class Bridge:
                     )
         except (TransportError, OSError) as exc:
             log.debug("control read loop ended: %s", exc)
+            failure = exc
         finally:
             for future in self._pending.values():
                 if not future.done():
+                    # A fresh instance per future: sharing one exception across
+                    # several would splice their tracebacks together.
                     future.set_exception(
-                        TransportError("the daemon connection dropped", code="DISCONNECTED")
+                        TransportError(failure.message, code=failure.code)
+                        if isinstance(failure, TransportError) and failure.code
+                        else TransportError("the daemon connection dropped", code="DISCONNECTED")
                     )
             self._pending.clear()
             self._progress.clear()

--- a/src/tbmcp/bridge.py
+++ b/src/tbmcp/bridge.py
@@ -113,7 +113,11 @@ class Bridge:
             if info is None:
                 raise TransportError("the daemon vanished right after starting", code="NO_DAEMON")
 
-        reader, writer = await asyncio.open_connection("127.0.0.1", info.port)
+        # `limit` is the stream buffer, and its default is 64 KiB — a thousandth
+        # of the ceiling ipc.MAX_LINE names. Past it `readline()` raises and the
+        # connection dies, so any answer over ~64 KB (a wide search, a bulk read)
+        # dropped the bridge instead of arriving.
+        reader, writer = await asyncio.open_connection("127.0.0.1", info.port, limit=ipc.MAX_LINE)
         self._next_id += 1
         await ipc.write_message(writer, {"t": "auth", "id": self._next_id, "token": info.token})
         reply = await asyncio.wait_for(ipc.read_message(reader), timeout=10.0)

--- a/src/tbmcp/daemon.py
+++ b/src/tbmcp/daemon.py
@@ -500,7 +500,9 @@ class Daemon:
 
     async def run(self) -> None:
         async with (
-            await asyncio.start_server(self._serve_control, host="127.0.0.1", port=0) as control,
+            await asyncio.start_server(
+                self._serve_control, host="127.0.0.1", port=0, limit=ipc.MAX_LINE
+            ) as control,
             serve(
                 self._serve_addon, host="127.0.0.1", port=0, max_size=CHUNK_LIMIT * 2
             ) as addon_server,

--- a/src/tbmcp/daemon.py
+++ b/src/tbmcp/daemon.py
@@ -41,6 +41,28 @@ DEFAULT_IDLE_TIMEOUT = 900.0
 ProgressCb = Callable[[dict[str, Any]], Awaitable[None]]
 
 
+def error_payload(exc: BaseException) -> dict[str, Any]:
+    """A failure in the protocol's `error` shape, ready to relay.
+
+    Uses `.message` rather than `str(exc)`. This hop re-serialises an error the
+    add-on already sent us structured, and `TbmcpError.__str__` renders `code` and
+    `needs` *into* the text for a human reader — so relaying that baked them into
+    the message, and the far side then rendered its own copy from the structured
+    fields it was also given. `[Error] [Error]` and a doubled `(requires: …)` were
+    both this. Round-tripping has to be idempotent, because it happens twice on
+    every add-on failure: once here, once in `Bridge.call`.
+    """
+    payload: dict[str, Any] = {
+        "kind": getattr(exc, "kind", "internal"),
+        "code": getattr(exc, "code", None),
+        "message": getattr(exc, "message", None) or str(exc),
+    }
+    needs = getattr(exc, "needs", None)
+    if needs:
+        payload["needs"] = needs
+    return payload
+
+
 @dataclass
 class _Pending:
     future: asyncio.Future[Any]
@@ -365,15 +387,7 @@ class Daemon:
                 on_progress=forward_progress if wants_progress else None,
             )
         except Exception as exc:
-            kind = getattr(exc, "kind", "internal")
-            payload: dict[str, Any] = {
-                "kind": kind,
-                "code": getattr(exc, "code", None),
-                "message": str(exc),
-            }
-            needs = getattr(exc, "needs", None)
-            if needs:
-                payload["needs"] = needs
+            payload = error_payload(exc)
             with contextlib.suppress(Exception):
                 await ipc.write_message(
                     writer, {"t": "res", "id": request_id, "ok": False, "error": payload}

--- a/src/tbmcp/ipc.py
+++ b/src/tbmcp/ipc.py
@@ -224,11 +224,20 @@ def new_token() -> str:
 
 
 async def read_message(reader: asyncio.StreamReader) -> dict[str, Any] | None:
-    """Read one newline-delimited JSON object. `None` means the peer hung up."""
+    """Read one newline-delimited JSON object. `None` means the peer hung up.
+
+    Both ends must be opened with `limit=MAX_LINE` (see `open_connection`), or the
+    ceiling is asyncio's 64 KiB default rather than the one below, and `readline`
+    raises `ValueError` instead of ever reaching the size check.
+    """
     try:
         line = await reader.readline()
     except (asyncio.IncompleteReadError, ConnectionResetError):
         return None
+    except ValueError as exc:
+        # The stream buffer filled before a newline arrived. Typed, so a caller
+        # sees a size problem rather than a connection that simply died.
+        raise TransportError("control message exceeded the maximum size", code="TOO_LARGE") from exc
     if not line:
         return None
     if len(line) > MAX_LINE:

--- a/src/tbmcp/server.py
+++ b/src/tbmcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import importlib
 import inspect
 import logging
@@ -9,15 +10,42 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from . import safety
 from .bridge import Bridge, set_shared_bridge
 from .config import ALL_TOOLSETS, Settings
+from .errors import TbmcpError
 
 log = logging.getLogger("tbmcp.server")
 
 F = TypeVar("F", bound=Callable[..., Any])
+
+
+def _speaking_errors(fn: F) -> F:
+    """Re-raise our own failures as the SDK's `ToolError`, which keeps the message.
+
+    An unrecognised exception is wrapped by mcp 2.1 as
+    `UnexpectedToolError("Error executing tool <name>")`, with the text dropped —
+    reasonably, since a stray exception's message is not written for a model to
+    read. Ours are: every `TbmcpError` says what the caller should do differently,
+    and losing that turns "pass at least one filter, `full_text` is usually what
+    you want" back into "something went wrong".
+
+    Raising `ToolError` is how a server says the message is deliberate. It is
+    understood by 2.0 and 2.1 alike, so this does not pin the dependency floor.
+    """
+
+    @functools.wraps(fn)
+    async def speaking(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await fn(*args, **kwargs)
+        except TbmcpError as exc:
+            raise ToolError(str(exc)) from exc
+
+    return speaking  # type: ignore[return-value]
+
 
 # Claude Code truncates server instructions at 2 KB, and with tool search on this
 # text is the primary discovery signal. Lead with what matters.
@@ -69,7 +97,7 @@ class Registrar:
             self.skipped.append(fn.__name__)
             return fn
         self.mcp.add_tool(
-            fn,
+            _speaking_errors(fn),
             title=title,
             # Normalise the docstring ourselves rather than letting the interpreter
             # decide: CPython 3.13 strips common leading whitespace from `__doc__` at

--- a/src/tbmcp/tools/mail.py
+++ b/src/tbmcp/tools/mail.py
@@ -132,12 +132,17 @@ def register(reg: Registrar) -> None:
             },
             timeout=90.0,
         )
+        # `searchedFolders` is reported when a walk starts, not on every page of
+        # it: the scope cannot change mid-walk, and computing it costs a subfolder
+        # enumeration. Omit the key rather than send a null, which would read as
+        # "scope unknown" instead of "already told you".
+        scope = result.get("searchedFolders")
         return page(
             [message_summary(m) for m in result.get("messages", [])],
             cursor=result.get("cursor"),
             total=result.get("totalAvailable"),
-            searchedFolders=result.get("searchedFolders"),
             indexNote=result.get("indexNote"),
+            **({"searchedFolders": scope} if scope is not None else {}),
         )
 
     @reg.read_tool(title="List a folder")

--- a/src/tbmcp/tools/mail.py
+++ b/src/tbmcp/tools/mail.py
@@ -71,6 +71,11 @@ def register(reg: Registrar) -> None:
         of already-indexed messages; `subject`/`author`/`body` are substring matches
         evaluated per folder. Dates are ISO-8601. Results are summaries — call
         `mail_get` for a body. Continue with `cursor=nextCursor`.
+
+        Case matters unevenly, because Thunderbird matches them differently:
+        `subject` and `body` are case-sensitive substring tests, while `author` and
+        `recipients` are matched as addresses and are not. Searching `subject` for
+        a lowercased word finds only the messages that spell it that way.
         """
         query: dict[str, Any] = {}
         if full_text:

--- a/src/tbmcp/tools/search.py
+++ b/src/tbmcp/tools/search.py
@@ -120,6 +120,8 @@ def register(reg: Registrar) -> None:
         `truncated` means the ranking only ordered the slice that was retrieved, so
         a deeper page may reorder and `matched` is a floor rather than a total.
         `totalAvailable` appears only when the whole result set came back.
+        `unmatchableTerms`, when present, lists words the index cannot match at
+        all — drop them and search again rather than concluding there is nothing.
         """
         if not query or not query.strip():
             raise UsageError("query is required — pass the words to search for.")
@@ -146,6 +148,14 @@ def register(reg: Registrar) -> None:
         # only do it when the whole result set came back.
         truncated = bool(result.get("truncated"))
         matched = result.get("matched")
+        extra: dict[str, Any] = {}
+        # Terms the index cannot match at all — "2.0" tokenizes to "2" and "0",
+        # both below the length floor — which under the default AND take the whole
+        # query down with them. The note explains it in prose; this is the same
+        # thing as data, so a caller can drop those words and retry without
+        # parsing a sentence.
+        if result.get("unmatchableTerms"):
+            extra["unmatchableTerms"] = result["unmatchableTerms"]
         return page(
             hits,
             total=None if truncated else matched,
@@ -155,6 +165,7 @@ def register(reg: Registrar) -> None:
             indexEnabled=result.get("indexEnabled"),
             note=result.get("note"),
             query=query,
+            **extra,
         )
 
     @reg.read_tool(title="Read a whole conversation", meta=large_output())

--- a/src/tbmcp/tools/search.py
+++ b/src/tbmcp/tools/search.py
@@ -116,6 +116,10 @@ def register(reg: Registrar) -> None:
 
         If this returns nothing unexpectedly, call `search_index_status`: the global
         indexer can be disabled or still catching up.
+
+        `truncated` means the ranking only ordered the slice that was retrieved, so
+        a deeper page may reorder and `matched` is a floor rather than a total.
+        `totalAvailable` appears only when the whole result set came back.
         """
         if not query or not query.strip():
             raise UsageError("query is required — pass the words to search for.")
@@ -132,12 +136,21 @@ def register(reg: Registrar) -> None:
         hits = result.get("hits") or result.get("messages") or []
         # `matched` is what the privileged half reports; there has never been a
         # `totalMatched`, so reading that key silently dropped the count from
-        # every result. `truncated` means the ranking only ordered the slice we
-        # retrieved, so a deeper page may reorder — worth surfacing.
+        # every result.
+        #
+        # It counts hits within what was actually retrieved, not across the
+        # corpus. Gloda has no cheap COUNT, so the retrieval is capped and sized
+        # from `offset + limit` — which means that when `truncated` is set the
+        # number is a floor, and one that moves as you page. Promoting that to
+        # `totalAvailable` would assert a total the search never established, so
+        # only do it when the whole result set came back.
+        truncated = bool(result.get("truncated"))
+        matched = result.get("matched")
         return page(
             hits,
-            total=result.get("matched"),
-            truncated=bool(result.get("truncated")),
+            total=None if truncated else matched,
+            truncated=truncated,
+            matched=matched,
             retrieved=result.get("retrieved"),
             indexEnabled=result.get("indexEnabled"),
             note=result.get("note"),

--- a/src/tbmcp/tools/search.py
+++ b/src/tbmcp/tools/search.py
@@ -130,9 +130,15 @@ def register(reg: Registrar) -> None:
             timeout=120.0,
         )
         hits = result.get("hits") or result.get("messages") or []
+        # `matched` is what the privileged half reports; there has never been a
+        # `totalMatched`, so reading that key silently dropped the count from
+        # every result. `truncated` means the ranking only ordered the slice we
+        # retrieved, so a deeper page may reorder — worth surfacing.
         return page(
             hits,
-            total=result.get("totalMatched"),
+            total=result.get("matched"),
+            truncated=bool(result.get("truncated")),
+            retrieved=result.get("retrieved"),
             indexEnabled=result.get("indexEnabled"),
             note=result.get("note"),
             query=query,
@@ -162,6 +168,7 @@ def register(reg: Registrar) -> None:
         result = await call("x.gloda.conversation", params, timeout=120.0)
         return page(
             result.get("messages") or [],
+            total=result.get("total"),
             conversationId=result.get("conversationId"),
             subject=result.get("subject"),
             participants=result.get("participants"),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,17 @@
-"""Shared fixtures. Nothing here needs Thunderbird, or even a daemon.
+"""Shared fixtures.
 
-The whole tool layer funnels through `Bridge.call`, so replacing the shared bridge
-with a recorder is enough to exercise every tool end to end through a real MCP
-client — argument validation, gating, and the shape of what comes back.
+Two kinds. The `fake_bridge` half needs no Thunderbird and no daemon: the whole
+tool layer funnels through `Bridge.call`, so replacing the shared bridge with a
+recorder exercises every tool end to end through a real MCP client — argument
+validation, gating, and the shape of what comes back.
+
+The `live_*` half at the bottom does the opposite, and exists because the first
+half cannot see the add-on at all.
 """
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 import pytest
@@ -97,3 +102,124 @@ def reset_settings():
     """Tool modules read the active policy from module state; keep tests isolated."""
     yield
     safety.set_settings(Settings())
+
+
+# --------------------------------------------------------------- live Thunderbird
+#
+# The fixtures above replace the bridge with a recorder, which is what lets the
+# suite run anywhere — and also why it never exercises the add-on. Five of the six
+# bugs in the search rewrite lived on that side and every one of them passed a
+# green run. The tests below drive a real Thunderbird instead, and skip when there
+# is not one, so CI stays green while a developer with the bridge up gets the
+# coverage the mocked suite cannot give.
+
+_MISSING = object()
+_corpus_cache: Any = _MISSING
+
+
+@pytest.fixture
+async def live_bridge():
+    """A bridge to a running Thunderbird, or skip.
+
+    `autostart=False` deliberately: spawning a daemon on a machine with no
+    Thunderbird would pay the spawn and attach timeouts on every CI run only to
+    fail at the end. Nothing advertised means nothing to test against.
+    """
+    from tbmcp import ipc
+
+    if ipc.DaemonInfo.load() is None:
+        pytest.skip("no tbmcp daemon advertised — these need a live Thunderbird")
+    bridge = bridge_module.Bridge(autostart=False)
+    try:
+        status = await bridge.status()
+    except Exception as exc:  # any transport failure means "not available"
+        await bridge.close()
+        pytest.skip(f"daemon unreachable: {exc}")
+    if not status.get("connected"):
+        await bridge.close()
+        pytest.skip("daemon is up but Thunderbird is not attached")
+    bridge_module.set_shared_bridge(bridge)  # type: ignore[arg-type]
+    try:
+        yield bridge
+    finally:
+        bridge_module.set_shared_bridge(None)
+        await bridge.close()
+
+
+@pytest.fixture
+async def live_tools(live_bridge):
+    """The read-only toolset, over a real client, against real mail."""
+    from mcp import Client
+
+    from tbmcp.server import build_server
+
+    settings = Settings().merged_with(toolsets=("mail", "folders", "search"), read_only=True)
+    async with Client(build_server(settings, bridge=live_bridge)) as client:
+        yield client
+
+
+async def _call(client, tool: str, args: dict[str, Any]) -> dict[str, Any]:
+    result = await client.call_tool(tool, args)
+    assert not result.is_error, " ".join(getattr(block, "text", "") for block in result.content)
+    return result.structured_content
+
+
+async def _discover(client) -> dict[str, Any] | None:
+    """The biggest folder this profile has, and a word its subjects share.
+
+    Nothing here may be hardcoded: the corpus is whatever mail the developer
+    running the suite happens to have. A profile too small or too uniform to
+    support a check skips it rather than failing it.
+    """
+    folders = (await _call(client, "folder_list", {"limit": 200}))["items"]
+    ranked = sorted(folders, key=lambda f: f.get("totalMessageCount") or 0, reverse=True)
+    for folder in ranked:
+        if (folder.get("totalMessageCount") or 0) < 40:
+            break
+        listed = await _call(client, "mail_list", {"folder_id": folder["id"], "limit": 50})
+        subjects = [m.get("subject") or "" for m in listed["items"]]
+        # Group case-insensitively so "Release" and "release" count together, but
+        # keep a spelling that was actually observed: `subject` is a case-sensitive
+        # substring match (msgHdr.mime2DecodedSubject.includes), so searching for a
+        # lowercased word finds only the messages that spell it that way.
+        counts: dict[str, int] = {}
+        seen_as: dict[str, str] = {}
+        for subject in subjects:
+            # One vote per subject: a word repeated inside one subject is not
+            # evidence that several messages share it.
+            words = {w for w in re.split(r"[^A-Za-z0-9]+", subject) if len(w) >= 4}
+            for word in {w.lower() for w in words}:
+                counts[word] = counts.get(word, 0) + 1
+            for word in words:
+                seen_as.setdefault(word.lower(), word)
+        shared = [word for word, n in sorted(counts.items(), key=lambda kv: -kv[1]) if n >= 5]
+        if shared:
+            return {
+                "folder_id": folder["id"],
+                "account_id": folder["accountId"],
+                "term": seen_as[shared[0]],
+                "total": folder["totalMessageCount"],
+            }
+    return None
+
+
+@pytest.fixture
+def call(live_tools):
+    """`await call("mail_search", {...})` -> the structured payload, or a failure
+    naming the tool that refused."""
+
+    async def invoke(tool: str, args: dict[str, Any]) -> dict[str, Any]:
+        return await _call(live_tools, tool, args)
+
+    return invoke
+
+
+@pytest.fixture
+async def corpus(live_tools):
+    """A folder and a search term this particular profile can exercise."""
+    global _corpus_cache
+    if _corpus_cache is _MISSING:
+        _corpus_cache = await _discover(live_tools)
+    if _corpus_cache is None:
+        pytest.skip("no folder with 40+ messages sharing a common subject word")
+    return _corpus_cache

--- a/tests/test_addon_build.py
+++ b/tests/test_addon_build.py
@@ -125,3 +125,57 @@ def test_a_module_that_does_not_announce_itself_is_rejected(tmp_path) -> None:
     )
     with pytest.raises(ValueError, match="TBX_MODULE_NAMES"):
         assemble_implementation(source)
+
+
+# --------------------------------------------------------- privileged sandbox rules
+#
+# The privileged half runs in the ext-*.js sandbox that
+# ExtensionCommon.sys.mjs::_createExtGlobal builds: system principal,
+# `wantGlobalProperties: ["ChromeUtils"]`, and an explicit Object.assign of
+# Services / Cc / Ci / Cu / Cr / IOUtils / PathUtils / XPCOMUtils. It is not a DOM
+# and it is not the same realm as the modules it talks to. Both facts have already
+# cost a release: each rule below marks a bug that shipped, produced no error the
+# Python layer could see, and silently disabled a whole toolset.
+
+
+def test_the_privileged_half_imports_its_own_timers(built) -> None:
+    """`setTimeout` is a DOM global and the sandbox has no DOM.
+
+    Calling it threw ReferenceError inside every H.withTimeout(), which rejected the
+    deadline before the work it guarded had started — taking out gloda search,
+    conversation lookup and the calendar/filters/junk deadlines at once.
+    """
+    _, _, implementation = built
+    assert "resource://gre/modules/Timer.sys.mjs" in implementation, (
+        "the privileged half must import setTimeout/clearTimeout from Timer.sys.mjs; "
+        "there is no timer function on the ext-*.js sandbox global"
+    )
+
+
+def test_the_privileged_half_does_not_brand_check_across_realms(built) -> None:
+    """`instanceof` is false for objects minted in another realm.
+
+    Gloda builds its Date objects in the shared system global, so `value instanceof
+    Date` in the sandbox was false for every one of them and every search hit came
+    back with `date: null` — which also flattened conversation ordering.
+    """
+    _, _, implementation = built
+    assert 'typeof value.getTime === "function"' in implementation, (
+        "dates coming back from gloda must be duck-typed, not brand-checked; a Date "
+        "built in another realm fails instanceof"
+    )
+
+
+def test_privileged_errors_survive_the_api_boundary(built) -> None:
+    """ExtensionCommon.normalizeError keeps a message only for a plain object, an
+    ExtensionError, or an error the extension's principal subsumes.
+
+    A plain `new Error` raised here is none of those, so it reached the caller as
+    "An unexpected error occurred" with the real text left in the Error Console.
+    That is what made the timer bug above take three days to find.
+    """
+    _, _, implementation = built
+    assert "resource://gre/modules/ExtensionUtils.sys.mjs" in implementation, (
+        "errors leaving invoke() must be wrapped in ExtensionError, or their message "
+        "is replaced with a generic string before anyone sees it"
+    )

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ from a broken install.
 
 from __future__ import annotations
 
+from tbmcp.daemon import error_payload
 from tbmcp.errors import (
     BlockedError,
     NotConnectedError,
@@ -63,3 +64,37 @@ def test_usage_errors_read_as_instructions() -> None:
     error = UsageError("subject is required", hint="pass subject")
     assert "subject is required" in str(error)
     assert "pass subject" in str(error)
+
+
+def test_relaying_an_error_does_not_render_it_into_its_own_message() -> None:
+    """The daemon re-serialises errors the add-on already sent structured, and the
+    bridge rebuilds them again on the far side. `__str__` folds `code` and `needs`
+    into the text for a human reader, so relaying that instead of `.message` made
+    each hop bake in another copy — which is how a blocked call arrived reading
+    "… (requires: x) [CODE] (requires: x)"."""
+    wire = {
+        "kind": "blocked",
+        "code": "NEEDS_CONSENT",
+        "message": "refusing to delete 40 messages",
+        "needs": ["confirm=true"],
+    }
+    once = error_payload(from_wire("mail_delete", wire))
+    assert once == wire, "one hop must be lossless and add nothing"
+
+    # Two hops is the real path: add-on -> daemon -> serve.
+    twice = error_payload(from_wire("mail_delete", once))
+    assert twice == wire, "relaying must be idempotent, not cumulative"
+
+    rebuilt = from_wire("mail_delete", twice)
+    assert rebuilt.message == "refusing to delete 40 messages"
+    assert rebuilt.needs == ["confirm=true"]
+    # The rendering still happens once, at the point a human reads it.
+    assert str(rebuilt).count("requires:") == 1
+    assert str(rebuilt).count("NEEDS_CONSENT") == 1
+
+
+def test_relaying_a_plain_exception_still_has_a_message() -> None:
+    payload = error_payload(RuntimeError("something went sideways"))
+    assert payload["message"] == "something went sideways"
+    assert payload["kind"] == "internal"
+    assert "needs" not in payload

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 import os
 
@@ -121,3 +122,48 @@ async def test_write_then_read_round_trip() -> None:
     frame = {"t": "req", "id": 7, "method": "prefs.get", "params": {"name": "a.b"}}
     await ipc.write_message(writer, frame)
     assert await ipc.read_message(_Reader(b"".join(writer.chunks))) == frame
+
+
+async def test_a_frame_larger_than_64k_survives_the_wire() -> None:
+    """asyncio's StreamReader defaults to a 64 KiB buffer — a thousandth of the
+    ceiling MAX_LINE names — and `readline()` raises past it, killing the
+    connection. Any answer over ~64 KB (a wide search, a bulk read) hit that
+    instead of arriving, so both ends have to be opened with an explicit limit."""
+    payload = {"t": "res", "id": 1, "ok": True, "result": {"blob": "x" * 200_000}}
+    received: list[dict] = []
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        await ipc.write_message(writer, payload)
+        await writer.drain()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0, limit=ipc.MAX_LINE)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        reader, writer = await asyncio.open_connection("127.0.0.1", port, limit=ipc.MAX_LINE)
+        received.append(await ipc.read_message(reader))
+        writer.close()
+    finally:
+        server.close()
+        await server.wait_closed()
+
+    assert received[0] == payload
+
+
+async def test_an_oversized_frame_is_a_typed_error_not_a_dead_socket() -> None:
+    """If the ceiling is ever genuinely exceeded, the caller should learn that it
+    was a size problem rather than watch the connection drop."""
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        writer.write(b"y" * 300_000)  # no newline: the buffer fills and never frames
+        await writer.drain()
+
+    server = await asyncio.start_server(handle, "127.0.0.1", 0)
+    port = server.sockets[0].getsockname()[1]
+    try:
+        reader, _writer = await asyncio.open_connection("127.0.0.1", port, limit=1024)
+        with pytest.raises(TransportError) as caught:
+            await ipc.read_message(reader)
+        assert caught.value.code == "TOO_LARGE"
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -8,6 +8,7 @@ import os
 
 import pytest
 
+from tbmcp import bridge as bridge_module
 from tbmcp import ipc
 from tbmcp.errors import TransportError
 
@@ -167,3 +168,45 @@ async def test_an_oversized_frame_is_a_typed_error_not_a_dead_socket() -> None:
     finally:
         server.close()
         await server.wait_closed()
+
+
+async def test_an_oversized_answer_reaches_the_caller_as_too_large() -> None:
+    """Raising TOO_LARGE inside `read_message` is not enough on its own.
+
+    `Bridge._read_loop` catches TransportError and its `finally` clause fails every
+    pending request with DISCONNECTED, so a typed size error was flattened back
+    into "the connection dropped" one layer above — the exact confusion the typed
+    error exists to end. A caller has to be able to tell an answer that was too big
+    from a socket that died, because only one of those is worth retrying.
+    """
+    bridge = bridge_module.Bridge(autostart=False)
+    reader = asyncio.StreamReader(limit=1024)
+    reader.feed_data(b"z" * 4096)  # no newline: the buffer fills and never frames
+    bridge._reader = reader
+
+    pending: asyncio.Future = asyncio.get_running_loop().create_future()
+    bridge._pending[1] = pending
+
+    await bridge._read_loop()
+
+    with pytest.raises(TransportError) as caught:
+        pending.result()
+    assert caught.value.code == "TOO_LARGE", f"surfaced as {caught.value.code}"
+
+
+async def test_a_genuinely_dropped_connection_still_says_so() -> None:
+    """The counterpart: an unexplained end is still DISCONNECTED, which is what
+    `Bridge.call` keys its reconnect-and-retry on."""
+    bridge = bridge_module.Bridge(autostart=False)
+    reader = asyncio.StreamReader()
+    reader.feed_eof()
+    bridge._reader = reader
+
+    pending: asyncio.Future = asyncio.get_running_loop().create_future()
+    bridge._pending[1] = pending
+
+    await bridge._read_loop()
+
+    with pytest.raises(TransportError) as caught:
+        pending.result()
+    assert caught.value.code == "DISCONNECTED"

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -210,3 +210,37 @@ async def test_a_genuinely_dropped_connection_still_says_so() -> None:
     with pytest.raises(TransportError) as caught:
         pending.result()
     assert caught.value.code == "DISCONNECTED"
+
+
+class _StubWriter:
+    """Just enough asyncio.StreamWriter for `_ensure`'s health test."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+    def is_closing(self) -> bool:
+        return self.closed
+
+
+async def test_the_read_pump_exiting_invalidates_the_connection() -> None:
+    """`_ensure` judges the connection by the writer alone, so a pump that has
+    stopped leaves it looking healthy.
+
+    The next call then posts its request into a socket nobody is reading and waits
+    out its whole timeout — 90s for mail_search, 120s for search_global — and so
+    does every call after it, because nothing ever reopens the connection. One
+    oversized answer wedged the bridge permanently.
+    """
+    bridge = bridge_module.Bridge(autostart=False)
+    reader = asyncio.StreamReader(limit=1024)
+    reader.feed_data(b"z" * 4096)  # overruns the frame ceiling, ending the pump
+    bridge._reader = reader
+    bridge._writer = _StubWriter()
+
+    await bridge._read_loop()
+
+    healthy = bridge._writer is not None and not bridge._writer.is_closing()
+    assert not healthy, "a stopped pump must not leave the connection looking usable"

--- a/tests/test_live_paging.py
+++ b/tests/test_live_paging.py
@@ -1,0 +1,109 @@
+"""Paging and cursors, against a real Thunderbird.
+
+Paging is the part of this server most easily wrong in a way that looks right: a
+page of plausible messages arrives, and only a comparison against a known-good
+reference shows that some are missing. Both defects below shipped, and both
+produced output a reader would accept.
+
+Skips itself when no Thunderbird is attached — see the `live_bridge` fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.anyio, pytest.mark.live]
+
+REFERENCE = 60
+
+
+async def _walk(call, tool: str, args: dict, step: int, stop_after: int) -> list[int]:
+    """Page `step` at a time, collecting ids, until the list ends."""
+    seen: list[int] = []
+    cursor = None
+    while len(seen) < stop_after:
+        page = await call(tool, {**args, "limit": step, **({"cursor": cursor} if cursor else {})})
+        seen += [m["id"] for m in page["items"]]
+        cursor = page.get("nextCursor")
+        if not cursor:
+            break
+    return seen
+
+
+@pytest.mark.parametrize("step", [1, 3, 7, 25])
+@pytest.mark.parametrize("tool", ["mail_list", "mail_search"])
+async def test_paging_conserves_the_set(call, corpus, tool, step) -> None:
+    """Thunderbird picks the page size and `messages.list` takes no override, so a
+    smaller `limit` used to strand the rest of the page: `continueList` advances to
+    the *next* page and those messages became unreachable. Paging a 586-message
+    folder three at a time skipped nine of every twelve.
+
+    Asserting that consecutive pages merely *differ* is not enough — that is what
+    the original check did, and it passed while printing ids 1,2,3 then 11,12,13.
+    Compare against one large call instead.
+    """
+    args = {
+        "mail_list": {"folder_id": corpus["folder_id"]},
+        "mail_search": {"subject": corpus["term"]},
+    }[tool]
+    reference = [m["id"] for m in (await call(tool, {**args, "limit": REFERENCE}))["items"]]
+    if len(reference) < 12:
+        pytest.skip(f"only {len(reference)} messages match; too few to page meaningfully")
+    walked = await _walk(call, tool, args, step, len(reference))
+    assert walked[: len(reference)] == reference
+
+
+async def test_a_cursor_reaches_the_end_of_a_short_result(call, corpus) -> None:
+    """A final page carries no list id, so stopping mid-page there had nothing to
+    hand back and the walk reported itself finished with messages still in hand."""
+    reference = [
+        m["id"]
+        for m in (await call("mail_list", {"folder_id": corpus["folder_id"], "limit": 12}))["items"]
+    ]
+    if len(reference) < 12:
+        pytest.skip("folder too small")
+    walked = await _walk(call, "mail_list", {"folder_id": corpus["folder_id"]}, 5, 12)
+    assert walked[:12] == reference
+
+
+async def test_an_evicted_cursor_refuses_rather_than_skipping(call, live_tools, corpus) -> None:
+    """The tail cache is bounded, and eviction reintroduced exactly the bug the
+    cache exists to prevent: the cursor is usually Thunderbird's own list id, so a
+    resume missed the cache, fell through to `continueList`, and returned the next
+    page — dropping the evicted messages silently.
+
+    The dangerous outcome here is a *successful* call.
+    """
+    outstanding = []
+    for _ in range(36):  # the cache holds 32
+        page = await call("mail_list", {"folder_id": corpus["folder_id"], "limit": 3})
+        if not page.get("nextCursor"):
+            pytest.skip("folder too small to leave part-read walks outstanding")
+        outstanding.append(page["nextCursor"])
+
+    result = await live_tools.call_tool(
+        "mail_list", {"folder_id": corpus["folder_id"], "limit": 3, "cursor": outstanding[0]}
+    )
+    assert result.is_error, (
+        "an evicted cursor answered as if it were a valid continuation, "
+        "which silently skips the messages its tail held"
+    )
+    text = " ".join(getattr(block, "text", "") for block in result.content)
+    assert "cursor" in text.lower(), text
+
+    # The newest cursor was never evicted and must still work.
+    still_good = await call(
+        "mail_list", {"folder_id": corpus["folder_id"], "limit": 3, "cursor": outstanding[-1]}
+    )
+    assert still_good["count"] > 0
+
+
+async def test_a_large_answer_survives_the_wire(call, corpus) -> None:
+    """`ipc.MAX_LINE` names a 64 MiB ceiling, but neither end passed a `limit` to
+    asyncio, so the real one was the 64 KiB StreamReader default. Past it
+    `readline()` raises and the connection dies, which is what made a wide search
+    look like a transport fault."""
+    got = await call("search_global", {"query": corpus["term"], "limit": 200})
+    if got["count"] < 90:
+        pytest.skip(f"only {got['count']} indexed matches; too few to exceed the old ceiling")
+    assert got["count"] > 85, "answers past roughly 64 KB used to drop the connection"

--- a/tests/test_live_search.py
+++ b/tests/test_live_search.py
@@ -1,0 +1,184 @@
+"""The search tools, against a real Thunderbird.
+
+The mocked suite cannot reach the add-on, where the search logic actually lives.
+Every assertion here failed against the shipped 1.2.0 and passes now; each one
+marks a bug that a green mocked run did not notice.
+
+Skips itself when no Thunderbird is attached — see the `live_bridge` fixture.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = [pytest.mark.anyio, pytest.mark.live]
+
+
+# --------------------------------------------------------------- the tools work
+
+
+async def test_substring_search_finds_mail(call, corpus) -> None:
+    """`returnMessageListId` changes messages.query's return type to a bare string,
+    and walking that string answered `{messages: [], cursor: null}` for every
+    query, with every filter, indexed or not."""
+    got = await call("mail_search", {"subject": corpus["term"], "limit": 5})
+    assert got["count"] > 0, f"nothing matched {corpus['term']!r}, which came from real subjects"
+
+
+async def test_substring_search_honours_a_folder(call, corpus) -> None:
+    got = await call(
+        "mail_search",
+        {"subject": corpus["term"], "folder_id": corpus["folder_id"], "limit": 5},
+    )
+    assert got["count"] > 0
+    assert {m["folderId"] for m in got["items"]} == {corpus["folder_id"]}
+
+
+async def test_search_reports_the_scope_it_covered(call, corpus) -> None:
+    """An empty result is only interpretable next to what was actually searched."""
+    got = await call(
+        "mail_search",
+        {"subject": corpus["term"], "folder_id": corpus["folder_id"], "limit": 5},
+    )
+    scope = got["searchedFolders"]
+    assert scope["scope"] == "folders"
+    assert corpus["folder_id"] in scope["folderIds"]
+
+
+async def test_global_search_returns_ranked_dated_hits(call, corpus) -> None:
+    """gloda.search threw `setTimeout is not defined` — the ext sandbox has no
+    timers — and every hit that did come back had `date: null`, because gloda's
+    Date objects fail `instanceof` across the sandbox boundary."""
+    got = await call("search_global", {"query": corpus["term"], "limit": 5})
+    if not got["count"]:
+        pytest.skip(f"{corpus['term']!r} is not in the global index on this profile")
+    assert all(h["score"] is not None for h in got["items"]), "ranking was lost"
+    assert all(h["date"] for h in got["items"]), "dates were dropped crossing the sandbox"
+    assert all(h["conversationId"] for h in got["items"])
+
+
+async def test_global_search_honours_a_folder(call, corpus) -> None:
+    """A folder id is `<key>:/<path>` and its path starts with "/", so it contains
+    "://" exactly like a URI does. Treating it as one — and splitting it one
+    character short — scoped every search to a folder that does not exist."""
+    got = await call(
+        "search_global",
+        {"query": corpus["term"], "limit": 20, "folder_id": corpus["folder_id"]},
+    )
+    if not got["count"]:
+        pytest.skip("nothing indexed in that folder for this term")
+    assert {h["folderId"] for h in got["items"]} == {corpus["folder_id"]}
+
+
+async def test_a_thread_rebuilds_oldest_first(call, corpus) -> None:
+    """With every date null the conversation sort collapsed to subject — identical
+    within a thread — so threads came back in arbitrary order."""
+    found = await call("search_global", {"query": corpus["term"], "limit": 5})
+    if not found["count"]:
+        pytest.skip("nothing indexed for this term")
+    seed = found["items"][0]
+    thread = await call("search_conversation", {"header_message_id": seed["headerMessageId"]})
+    dates = [m["date"] for m in thread["items"]]
+    assert all(dates), "a thread with undated messages cannot be ordered"
+    assert dates == sorted(dates), "not oldest-first"
+    assert thread["participants"], "participants was read but never written"
+
+
+async def test_a_thread_is_reachable_by_either_identifier(call, corpus) -> None:
+    found = await call("search_global", {"query": corpus["term"], "limit": 5})
+    if not found["count"]:
+        pytest.skip("nothing indexed for this term")
+    seed = found["items"][0]
+    by_id = await call("search_conversation", {"message_id": seed["id"]})
+    for reference in (seed["headerMessageId"], f"<{seed['headerMessageId']}>"):
+        by_header = await call("search_conversation", {"header_message_id": reference})
+        assert by_header["conversationId"] == by_id["conversationId"], reference
+
+
+async def test_the_index_reports_how_much_it_holds(call) -> None:
+    """`indexedMessages` was null because the count was wrapped in the same
+    withTimeout that could not find setTimeout, and the failure was caught."""
+    stats = await call("search_index_status", {})
+    if not stats.get("enabled"):
+        pytest.skip("the global index is disabled on this profile")
+    assert isinstance(stats["indexedMessages"], int)
+
+
+# ------------------------------------------------------- boundaries and limits
+
+
+@pytest.mark.parametrize("limit", [1, 2, 200])
+@pytest.mark.parametrize("tool", ["mail_search", "mail_list", "search_global"])
+async def test_every_tool_honours_its_documented_range(call, corpus, tool, limit) -> None:
+    """`limit` is clamped to 200, and a defect lived at 90 for as long as nobody
+    asked for more than 5: answers past roughly 64 KB dropped the connection,
+    because the stream buffer was left at asyncio's default."""
+    args = {
+        "mail_search": {"subject": corpus["term"]},
+        "mail_list": {"folder_id": corpus["folder_id"]},
+        "search_global": {"query": corpus["term"]},
+    }[tool]
+    got = await call(tool, {**args, "limit": limit})
+    assert 0 <= got["count"] <= limit, f"asked for {limit}, got {got['count']}"
+
+
+async def test_a_bad_folder_reference_says_why(call, live_tools) -> None:
+    """Errors raised in the privileged half reached the caller as the generic
+    "An unexpected error occurred", with the real text stranded in the Error
+    Console. That is what made the timer bug take days to find."""
+    result = await live_tools.call_tool(
+        "search_global", {"query": "anything", "folder_id": "accountZZ://nope"}
+    )
+    assert result.is_error
+    text = " ".join(getattr(block, "text", "") for block in result.content)
+    assert "accountZZ" in text, text
+    assert "unexpected error" not in text, text
+
+
+# ---------------------------------------------------------- invariants of search
+
+
+async def test_offset_windows_one_ordering(call, corpus) -> None:
+    """`offset` has to be a window onto a single ranking, not a fresh search."""
+    full = await call("search_global", {"query": corpus["term"], "limit": 10})
+    if full["count"] < 10:
+        pytest.skip("too few indexed matches to window")
+    tail = await call("search_global", {"query": corpus["term"], "limit": 5, "offset": 5})
+    assert [h["id"] for h in tail["items"]] == [h["id"] for h in full["items"][5:10]]
+
+
+async def test_a_folder_filter_selects_and_never_invents(call, corpus) -> None:
+    """Scoping picks from the corpus matches; it cannot produce a hit the unscoped
+    search did not have.
+
+    Only comparable when neither side was cut off by `limit` — otherwise these are
+    two different top-N slices, and a folder hit ranked below the unscoped cut
+    legitimately appears in one and not the other.
+    """
+    unscoped = await call("search_global", {"query": corpus["term"], "limit": 200})
+    scoped = await call(
+        "search_global",
+        {"query": corpus["term"], "limit": 200, "folder_id": corpus["folder_id"]},
+    )
+    complete = (
+        not unscoped.get("truncated")
+        and not scoped.get("truncated")
+        and unscoped["count"] == unscoped.get("matched")
+        and scoped["count"] == scoped.get("matched")
+    )
+    if not complete:
+        pytest.skip("the corpus caps one side, so the two are different top-N slices")
+    assert {h["id"] for h in scoped["items"]} == {
+        h["id"] for h in unscoped["items"] if h["folderId"] == corpus["folder_id"]
+    }
+
+
+async def test_an_exact_total_is_not_called_truncated(call, corpus) -> None:
+    """A LIMIT that comes back exactly full cannot tell "this is everything" from
+    "the cap cut it off", so the searcher over-fetches one row. When it says the
+    result was complete, the count has to be exact."""
+    got = await call("search_global", {"query": corpus["term"], "limit": 200})
+    if got.get("truncated"):
+        pytest.skip("this term genuinely exceeds the retrieval cap")
+    assert got["totalAvailable"] == got["matched"]
+    assert got["count"] == min(got["matched"], 200)

--- a/tests/test_tools_mail.py
+++ b/tests/test_tools_mail.py
@@ -211,3 +211,31 @@ async def test_get_many_has_a_ceiling(fake_bridge) -> None:
         result = await client.call_tool("mail_get_many", {"message_ids": list(range(51))})
     assert result.is_error
     assert "50" in _text(result)
+
+
+async def test_search_reports_the_scope_it_searched(fake_bridge) -> None:
+    """An empty result is only interpretable next to what was actually searched."""
+    scope = {
+        "scope": "folders",
+        "accountIds": ["account1"],
+        "folderIds": ["account1://INBOX"],
+        "includeSubFolders": True,
+    }
+    bridge = fake_bridge({"messages.query": {"messages": [], "searchedFolders": scope}})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("mail_search", {"subject": "nothing", "limit": 5})
+
+    assert result.structured_content["searchedFolders"] == scope
+
+
+async def test_continuing_a_search_does_not_restate_the_scope(fake_bridge) -> None:
+    """The add-on computes the scope only when a walk starts, because it cannot
+    change mid-walk and costs a subfolder enumeration. The key is then absent
+    rather than null: null would read as "scope unknown"."""
+    bridge = fake_bridge({"messages.query": {"messages": [], "cursor": None}})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool(
+            "mail_search", {"subject": "nothing", "cursor": "list-1", "limit": 5}
+        )
+
+    assert "searchedFolders" not in result.structured_content

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -1,0 +1,157 @@
+"""The search toolset, through a real in-memory MCP client.
+
+Every test here guards a field the Python layer *read* but the privileged half had
+never written. That class of bug is invisible: the key is simply absent, `.get()`
+returns None, and the tool answers with a confident-looking envelope that has
+quietly dropped the count, the participants, or the scope it searched. A fake
+bridge returning the add-on's real shape is enough to pin each one down.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp import Client
+
+from tbmcp.config import Settings
+from tbmcp.server import build_server
+
+pytestmark = pytest.mark.anyio
+
+HIT = {
+    "id": 110,
+    "glodaId": 2154,
+    "headerMessageId": "abc@example.com",
+    "subject": "Pending release items",
+    "author": "Supplier <billing@example.com>",
+    "date": "2026-08-26T01:25:23.000Z",
+    "folderId": "account1://INBOX",
+    "folderUri": "imap://me@example.com/INBOX",
+    "conversationId": 718,
+    "score": 59,
+}
+
+
+def _server(bridge, **overrides):
+    return build_server(Settings().merged_with(toolsets=("search",), **overrides), bridge=bridge)
+
+
+def _text(result) -> str:
+    return " ".join(getattr(block, "text", "") for block in result.content)
+
+
+async def test_global_search_reports_how_many_matched(fake_bridge) -> None:
+    """The privileged half reports `matched`; reading `totalMatched` instead meant
+    every ranked search came back without a count."""
+    bridge = fake_bridge(
+        {
+            "x.gloda.search": {
+                "query": "release",
+                "hits": [HIT],
+                "matched": 33,
+                "retrieved": 50,
+                "truncated": True,
+                "indexEnabled": True,
+            }
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "release", "limit": 5})
+
+    assert not result.is_error, _text(result)
+    payload = result.structured_content
+    assert payload["totalAvailable"] == 33
+    assert payload["retrieved"] == 50
+    # The ranking only ordered what was retrieved, so a deeper page may reorder.
+    assert payload["truncated"] is True
+    assert payload["items"][0]["conversationId"] == 718
+
+
+async def test_a_complete_ranking_is_not_flagged_as_truncated(fake_bridge) -> None:
+    bridge = fake_bridge(
+        {
+            "x.gloda.search": {
+                "hits": [HIT],
+                "matched": 1,
+                "retrieved": 1,
+                "truncated": False,
+                "indexEnabled": True,
+            }
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "release"})
+
+    assert "truncated" not in result.structured_content
+
+
+async def test_global_search_surfaces_the_note_explaining_an_empty_result(fake_bridge) -> None:
+    """An empty ranked search is only actionable if it says why it was empty."""
+    note = 'The index cannot match "2.0" — it tokenizes into pieces shorter than three'
+    bridge = fake_bridge(
+        {"x.gloda.search": {"hits": [], "matched": 0, "indexEnabled": True, "note": note}}
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "widget 2.0"})
+
+    payload = result.structured_content
+    assert payload["count"] == 0
+    assert payload["note"] == note
+
+
+async def test_conversation_reports_participants_and_length(fake_bridge) -> None:
+    """`participants` and `total` are the two fields that make a thread summary
+    usable without reading every message back."""
+    bridge = fake_bridge(
+        {
+            "x.gloda.conversation": {
+                "conversationId": 718,
+                "subject": "Pending release items",
+                "participants": ["Ada <ada@example.com>", "Bo <bo@example.com>"],
+                "messages": [HIT],
+                "total": 8,
+            }
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_conversation", {"message_id": 110})
+
+    assert not result.is_error, _text(result)
+    payload = result.structured_content
+    assert payload["conversationId"] == 718
+    assert payload["participants"] == ["Ada <ada@example.com>", "Bo <bo@example.com>"]
+    # `total` is the whole thread; `count` is only what this page carried.
+    assert payload["totalAvailable"] == 8
+    assert payload["count"] == 1
+
+
+async def test_conversation_accepts_either_identifier(fake_bridge) -> None:
+    bridge = fake_bridge({"x.gloda.conversation": {"messages": [], "conversationId": 1}})
+    async with Client(_server(bridge)) as client:
+        await client.call_tool("search_conversation", {"message_id": 110})
+        assert bridge.params_for("x.gloda.conversation")["messageId"] == 110
+
+        bridge.calls.clear()
+        await client.call_tool("search_conversation", {"header_message_id": "abc@example.com"})
+        assert bridge.params_for("x.gloda.conversation")["headerMessageId"] == "abc@example.com"
+
+
+async def test_conversation_needs_one_of_the_two_identifiers(fake_bridge) -> None:
+    bridge = fake_bridge()
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_conversation", {})
+
+    assert result.is_error
+    assert bridge.calls == []
+
+
+async def test_global_search_forwards_the_folder_scope(fake_bridge) -> None:
+    """Scoping happens in the privileged half; the tool has to actually send it."""
+    bridge = fake_bridge({"x.gloda.search": {"hits": [], "matched": 0, "indexEnabled": True}})
+    async with Client(_server(bridge)) as client:
+        await client.call_tool(
+            "search_global", {"query": "release", "folder_id": "account1://INBOX", "offset": 10}
+        )
+
+    params = bridge.params_for("x.gloda.search")
+    assert params["folderId"] == "account1://INBOX"
+    assert params["offset"] == 10

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -48,8 +48,8 @@ async def test_global_search_reports_how_many_matched(fake_bridge) -> None:
                 "query": "release",
                 "hits": [HIT],
                 "matched": 33,
-                "retrieved": 50,
-                "truncated": True,
+                "retrieved": 33,
+                "truncated": False,
                 "indexEnabled": True,
             }
         }
@@ -60,10 +60,34 @@ async def test_global_search_reports_how_many_matched(fake_bridge) -> None:
     assert not result.is_error, _text(result)
     payload = result.structured_content
     assert payload["totalAvailable"] == 33
-    assert payload["retrieved"] == 50
-    # The ranking only ordered what was retrieved, so a deeper page may reorder.
-    assert payload["truncated"] is True
+    assert payload["matched"] == 33
+    assert payload["retrieved"] == 33
     assert payload["items"][0]["conversationId"] == 718
+
+
+async def test_a_capped_ranking_does_not_claim_a_total(fake_bridge) -> None:
+    """`matched` counts hits inside a capped retrieval whose size is derived from
+    `offset + limit`, so under truncation it is a floor that moves as you page.
+    Reporting it as `totalAvailable` would assert a total nobody measured."""
+    bridge = fake_bridge(
+        {
+            "x.gloda.search": {
+                "hits": [HIT],
+                "matched": 75,
+                "retrieved": 1000,
+                "truncated": True,
+                "indexEnabled": True,
+            }
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "release", "limit": 5})
+
+    payload = result.structured_content
+    assert "totalAvailable" not in payload
+    # The floor is still worth having, just not under a name that means "total".
+    assert payload["matched"] == 75
+    assert payload["truncated"] is True
 
 
 async def test_a_complete_ranking_is_not_flagged_as_truncated(fake_bridge) -> None:
@@ -81,7 +105,9 @@ async def test_a_complete_ranking_is_not_flagged_as_truncated(fake_bridge) -> No
     async with Client(_server(bridge)) as client:
         result = await client.call_tool("search_global", {"query": "release"})
 
-    assert "truncated" not in result.structured_content
+    payload = result.structured_content
+    assert "truncated" not in payload
+    assert payload["totalAvailable"] == 1
 
 
 async def test_global_search_surfaces_the_note_explaining_an_empty_result(fake_bridge) -> None:

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -181,3 +181,31 @@ async def test_global_search_forwards_the_folder_scope(fake_bridge) -> None:
     params = bridge.params_for("x.gloda.search")
     assert params["folderId"] == "account1://INBOX"
     assert params["offset"] == 10
+
+
+async def test_unmatchable_terms_reach_the_caller(fake_bridge) -> None:
+    """The privileged half names the words the index cannot match; a caller that
+    only gets them inside a prose `note` has to parse a sentence to act on it."""
+    bridge = fake_bridge(
+        {
+            "x.gloda.search": {
+                "hits": [],
+                "matched": 0,
+                "indexEnabled": True,
+                "note": 'The index cannot match "2.0" — it tokenizes into pieces…',
+                "unmatchableTerms": ["2.0"],
+            }
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "widget 2.0"})
+
+    assert result.structured_content["unmatchableTerms"] == ["2.0"]
+
+
+async def test_a_searchable_query_carries_no_unmatchable_terms(fake_bridge) -> None:
+    bridge = fake_bridge({"x.gloda.search": {"hits": [HIT], "matched": 1, "indexEnabled": True}})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "widget"})
+
+    assert "unmatchableTerms" not in result.structured_content


### PR DESCRIPTION
Fixes #3 — every search tool in 1.2.0, from six independent bugs. Full diagnosis is in the issue; this is what changed and how it was checked.

## The six

1. **`mail_search` returned zero for every query.** `returnMessageListId: true` changes `messages.query`'s return type to a bare id string (`MessageList | string`), and `takePage` walked the string. Resolve the id into its first page first. — `background/handlers/messages.js`
2. **`setTimeout is not defined` in the privileged half.** The ext-\*.js sandbox has no timers, so every `H.withTimeout()` rejected before the work it guarded began — taking out gloda search and conversation, nulling `gloda.stats`' count, and removing the calendar/filters/junk deadlines. Import from `Timer.sys.mjs`; also clear the timer on settle, which the original never did. — `experiment/core.js`
3. **Every gloda hit reported `date: null`.** `instanceof Date` is false across the sandbox boundary. That also flattened `gloda.conversation`'s ordering to subject, so threads came back unordered. Duck-type instead. — `experiment/modules/gloda.js`
4. **Folder-scoped `search_global` matched nothing**, from a `"://"` test that mistakes a folder id for a URI *and* an off-by-one in the `:/` split. Resolve the key against the account manager and match a hit on either `folderId` or `folderUri`. — `experiment/modules/gloda.js`
5. **A term the indexer tokenizes away zeroed the whole query** under AND. Now reported in `note` and in a new `unmatchableTerms` field. Query semantics are unchanged — nothing is silently dropped. — `experiment/modules/gloda.js`
6. **Every privileged error arrived as "An unexpected error occurred."** `normalizeError` keeps a message only for an `ExtensionError` (or a plain object, or an error the extension's principal subsumes). `invoke()` now rethrows as an `ExtensionError` tagged `tbx:<kind>:<message>` that the background page unpacks, so the taxonomy survives too; and a bare `name` of `"Error"` is no longer reported as a code. — `experiment/core.js`, `background/handlers/privileged.js`, `background/registry.js`

Plus four fields the Python layer read that nothing wrote: `searchedFolders` (now `{scope, accountIds, folderIds?, includeSubFolders}`, mirroring `MessageQuery.startSearch`'s own scoping rule), `participants` (from gloda's `involves`), conversation `total`, and `search_global`'s count — read as `totalMatched`, produced as `matched`. — `tools/search.py`

## Tests

194 → 204, ruff clean.

- `tests/test_tools_search.py` (new) pins the dead fields through a real MCP client. Two of its seven fail on unpatched `search.py`.
- Three guards appended to `tests/test_addon_build.py` pin the sandbox rules — import timers, no cross-realm brand checks, wrap errors so the message survives. **All three fail on the unpatched add-on.** They live there because that file already exists to catch traps that "fail silently at the Python level", which is exactly what these are.

Bugs 1 and 4 are behavioural and need a live Thunderbird, so CI cannot reach them. I verified those against a real profile (Thunderbird 153.1.1, ~2,185 indexed messages, three IMAP accounts) with a 28-check acceptance script covering all four tools, both conversation identifiers, folder scoping, paging, thread ordering, and the error path. Happy to contribute that script separately if you want it in-tree — it needs a running Thunderbird, so it would not fit the current CI.

## Worth a look separately

`pyproject.toml` floors `mcp>=2.0.0,<3`, but on `mcp` 2.1.1 five existing tests fail: tool errors are wrapped in `UnexpectedToolError(f"Error executing tool {self.name}")` and the message no longer reaches the client. Same shape as bug 6, one layer up. I pinned `mcp==2.0.0` locally to get a clean baseline and did not touch the floor here, since the right fix is probably raising `ToolError` rather than constraining the dependency.

Also worth knowing: all 194 tests passed on the completely broken code, because `conftest.py` replaces the bridge with a recorder and the add-on layer is never exercised. The three structural guards are a partial answer; a real one probably means a JS test step.
