### PR TITLE
Add --tools: allow individual tools on top of --toolsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,22 @@ tbmcp serve --toolsets +calendar        # the default set plus one
 tbmcp tools --toolsets all              # list what would be registered
 ```
 
+### One tool at a time
+
+A toolset is all or nothing, which is coarse when a single tool inside a group is
+the one you want. `--tools` names individuals, from any toolset, and a tool named
+there is allowed to write even under `--read-only`:
+
+```bash
+# read everything, write a draft, send nothing
+tbmcp serve --read-only --toolsets mail,folders,search \
+  --tools mail_draft_save,mail_compose_open,mail_send_status
+```
+
+`mail_send`, `mail_reply` and `mail_forward` stay unregistered, so no confirmation
+gate has to hold the line: a model cannot call a tool it was never told about. An
+unknown name is a startup error rather than a tool that is quietly missing.
+
 <!-- BEGIN GENERATED TOOL CATALOGUE -->
 112 tools across 10 toolsets; 48 of them read-only.
 Full signatures in [docs/TOOL-REFERENCE.md](docs/TOOL-REFERENCE.md).
@@ -435,7 +451,8 @@ Beyond the gate:
 - **Private keys never move.** OpenPGP keys can be listed and public keys exported;
   asking for secret key material is refused by design.
 - **`--read-only`** registers no mutating tools at all, which makes a safe second
-  registration easy.
+  registration easy. `--tools <name>` is its one exception, and it is granted per
+  tool: enough to allow `mail_draft_save` without allowing `mail_send`.
 - **`--yolo`** removes every gate. It exists for scripted use. Do not leave it on.
 
 ---

--- a/src/tbmcp/bootstrap.py
+++ b/src/tbmcp/bootstrap.py
@@ -751,10 +751,14 @@ def _rerun_without_dry_run(options: Options) -> str:
         parts.append(f'--venv "{options.venv}"')
     if options.clients:
         parts.append(f"--clients {','.join(options.clients)}")
+    # Quoted like the paths above, because both of these accept whitespace that the
+    # parsers then strip: `--tools "a, b"` is valid input, and rendering it bare puts
+    # `b` back on the command line as a stray positional. The rerun line is the one
+    # thing a dry run exists to produce, so it has to survive being pasted.
     if options.toolsets:
-        parts.append(f"--toolsets {options.toolsets}")
+        parts.append(f'--toolsets "{options.toolsets}"')
     if options.tools:
-        parts.append(f"--tools {options.tools}")
+        parts.append(f'--tools "{options.tools}"')
     if options.source:
         parts.append(f'--source "{options.source}"')
     if options.skip_addon:

--- a/src/tbmcp/bootstrap.py
+++ b/src/tbmcp/bootstrap.py
@@ -364,6 +364,7 @@ class Options:
     venv: pathlib.Path | None = None
     clients: tuple[str, ...] = ()
     toolsets: str | None = None
+    tools: str | None = None
     json_out: bool = False
     dry_run: bool = False
     skip_addon: bool = False
@@ -636,6 +637,8 @@ def _step_clients(options: Options, state: dict, run: Runner) -> tuple[str, str]
     argv = [state["venv_python"], "-m", "tbmcp", "setup", *clients]
     if options.toolsets:
         argv += ["--toolsets", options.toolsets]
+    if options.tools:
+        argv += ["--tools", options.tools]
     status, output = run(argv)
     if status != 0:
         return "failed", output.strip() or "client setup failed"
@@ -656,6 +659,8 @@ def _step_verify(options: Options, state: dict, run: Runner) -> tuple[str, str]:
     argv = [state["venv_python"], "-m", "tbmcp", "doctor", "--json"]
     if options.toolsets:
         argv += ["--toolsets", options.toolsets]
+    if options.tools:
+        argv += ["--tools", options.tools]
     status, output = run(argv)
     payload = _json_field_report(output)
     if status != 0 or payload is None or not payload.get("ok"):
@@ -748,6 +753,8 @@ def _rerun_without_dry_run(options: Options) -> str:
         parts.append(f"--clients {','.join(options.clients)}")
     if options.toolsets:
         parts.append(f"--toolsets {options.toolsets}")
+    if options.tools:
+        parts.append(f"--tools {options.tools}")
     if options.source:
         parts.append(f'--source "{options.source}"')
     if options.skip_addon:
@@ -812,6 +819,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument("--venv", type=pathlib.Path, help="where to put the environment")
     parser.add_argument("--clients", help="comma separated; default: auto-detect installed clients")
     parser.add_argument("--toolsets", help="passed through to setup")
+    parser.add_argument("--tools", help="passed through to setup")
     parser.add_argument("--source", help=f"install from here (default: {GIT_SOURCE})")
     parser.add_argument("--skip-addon", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
@@ -824,6 +832,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             venv=args.venv,
             clients=tuple(c.strip() for c in (args.clients or "").split(",") if c.strip()),
             toolsets=args.toolsets,
+            tools=args.tools,
             json_out=args.json_out,
             dry_run=args.dry_run,
             skip_addon=args.skip_addon,

--- a/src/tbmcp/bootstrap.py
+++ b/src/tbmcp/bootstrap.py
@@ -667,12 +667,12 @@ def _step_verify(options: Options, state: dict, run: Runner) -> tuple[str, str]:
         return "failed", output.strip() or "doctor reported a problem"
     tool_call = payload.get("tbStatusCall")
     if isinstance(tool_call, dict) and tool_call.get("skipped"):
-        # A deselected `admin` toolset is a supported configuration, not a broken
+        # A configuration without `tb_status` registered is supported, not a broken
         # chain — `doctor`'s own `ok` already accounts for it (see `_doctor_ok`).
         # Say so here too, rather than claiming a check that never ran.
         return (
             "ok",
-            "doctor: healthy (bridge connected; tb_status not checked — admin toolset not selected)",
+            "doctor: healthy (bridge connected; tb_status not checked — it is not registered)",
         )
     return "ok", "doctor: healthy (bridge connected, tb_status tool call verified)"
 

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -488,6 +488,11 @@ def build_parser() -> argparse.ArgumentParser:
     boot.add_argument("--venv")
     boot.add_argument("--clients", help="comma separated; default: auto-detect installed clients")
     boot.add_argument("--toolsets")
+    # Needed even though bootstrap only forwards it. argparse accepts any unambiguous
+    # prefix, so without this `--tools X` is silently read as `--toolsets X` and travels
+    # on as a toolset name — failing later, in a different command, with a message that
+    # names something the caller never typed.
+    boot.add_argument("--tools")
     boot.add_argument("--source")
     boot.add_argument("--skip-addon", action="store_true")
     boot.add_argument("--dry-run", action="store_true")

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -112,10 +112,13 @@ def _doctor_ok(report: dict) -> bool:
     real MCP tool-calling machinery, the same path a client uses) have to say
     `connected`. Checking only one would let the other silently regress unnoticed.
 
-    Exception: when the `admin` toolset was deselected, `tb_status` was never
-    registered at all — `report["tbStatusCall"]` then carries `skipped`, not
-    `connected` or `error`. That is a supported configuration, not a broken chain,
-    so it must not sink `ok` the way a genuine dispatch failure would.
+    Exception: when `tb_status` was never registered — the `admin` toolset is not
+    selected and `--tools` does not name it — `report["tbStatusCall"]` carries
+    `skipped`, not `connected` or `error`. That is a supported configuration, not a
+    broken chain, so it must not sink `ok` the way a genuine dispatch failure would.
+    Note that this hinges on `cmd_doctor` skipping only when the tool really is
+    absent: a skip recorded for a tool that *was* registered would turn this
+    exemption into a way to pass without testing anything.
     """
     bridge_state = report.get("bridge")
     tool_call = report.get("tbStatusCall")
@@ -187,13 +190,22 @@ def cmd_doctor(args: argparse.Namespace) -> int:
         set_shared_bridge(bridge)
         try:
             mcp = build_server(settings, bridge=bridge)
-            if "admin" not in settings.toolsets:
-                # tb_status lives in the admin toolset. Calling it anyway would just
-                # raise `ToolError: Unknown tool: tb_status` — indistinguishable, to a
-                # naive check, from the tool genuinely failing. Record the real reason
-                # instead of dispatching a call we already know cannot succeed.
+            # Ask the server what it registered rather than predicting it from the
+            # toolset selection. `--tools tb_status` registers the tool without
+            # selecting `admin`, so the two questions stopped being the same one —
+            # and answering the wrong one here means reporting a healthy chain
+            # without ever having exercised it.
+            registered = {tool.name for tool in await mcp.list_tools()}
+            if "tb_status" not in registered:
+                # Dispatching anyway would just raise `ToolError: Unknown tool:
+                # tb_status` — indistinguishable, to a naive check, from the tool
+                # genuinely failing. Record the real reason instead of making a call
+                # we already know cannot succeed.
                 report["tbStatusCall"] = {
-                    "skipped": "admin toolset not selected; tb_status is not registered"
+                    "skipped": (
+                        "tb_status is not registered (the admin toolset is not "
+                        "selected and --tools does not name it)"
+                    )
                 }
             else:
                 result = await mcp.call_tool("tb_status", {})

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -17,7 +17,7 @@ import os
 import sys
 from collections.abc import Sequence
 
-from .config import ALL_TOOLSETS, Settings, parse_toolsets
+from .config import ALL_TOOLSETS, Settings, parse_tools, parse_toolsets
 
 
 def _configure_logging(verbose: bool) -> None:
@@ -33,8 +33,10 @@ def _configure_logging(verbose: bool) -> None:
 def _settings_from_args(args: argparse.Namespace) -> Settings:
     settings = Settings.from_env()
     toolsets = parse_toolsets(args.toolsets) if getattr(args, "toolsets", None) else None
+    named = getattr(args, "tools", None)
     return settings.merged_with(
         toolsets=toolsets,
+        extra_tools=parse_tools(named) if named else None,
         read_only=True if getattr(args, "read_only", False) else None,
         yolo=True if getattr(args, "yolo", False) else None,
         unsafe_prefs=True if getattr(args, "unsafe_prefs", False) else None,
@@ -355,7 +357,8 @@ def cmd_tools(args: argparse.Namespace) -> int:
     for row in rows:
         marker = "r" if row["readOnly"] else ("!" if row["destructive"] else "w")
         print(f"  [{marker}] {row['name']:<34} {row['title'] or ''}")
-    print(f"\n{len(rows)} tools from toolsets: {','.join(settings.toolsets)}")
+    named = f" (+{','.join(settings.extra_tools)} by name)" if settings.extra_tools else ""
+    print(f"\n{len(rows)} tools from toolsets: {','.join(settings.toolsets)}{named}")
     return 0
 
 
@@ -363,7 +366,7 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
     from .bootstrap import main as bootstrap_main
 
     forwarded: list[str] = []
-    for flag in ("python", "venv", "clients", "toolsets", "source"):
+    for flag in ("python", "venv", "clients", "toolsets", "tools", "source"):
         value = getattr(args, flag, None)
         if value:
             forwarded += [f"--{flag}", str(value)]
@@ -391,6 +394,11 @@ def build_parser() -> argparse.ArgumentParser:
             help=f"comma separated: {','.join(ALL_TOOLSETS)}, all, or +extra (default: lean set)",
         )
         sub.add_argument("--read-only", action="store_true", help="register no mutating tools")
+        sub.add_argument(
+            "--tools",
+            help="comma separated tool names to register on top of --toolsets; a tool "
+            "named here is allowed to write even under --read-only",
+        )
         sub.add_argument(
             "--yolo", action="store_true", help="skip every confirmation gate (dangerous)"
         )

--- a/src/tbmcp/clients.py
+++ b/src/tbmcp/clients.py
@@ -157,6 +157,8 @@ def _serve_args(settings: Settings) -> list[str]:
     toolsets = tuple(settings.toolsets)
     if toolsets != DEFAULT_TOOLSETS:
         args += ["--toolsets", "all" if toolsets == ALL_TOOLSETS else ",".join(toolsets)]
+    if settings.extra_tools:
+        args += ["--tools", ",".join(settings.extra_tools)]
     if settings.read_only:
         args.append("--read-only")
     if settings.send_mode == "send":

--- a/src/tbmcp/config.py
+++ b/src/tbmcp/config.py
@@ -107,7 +107,12 @@ class Settings:
     autostart_daemon: bool = True
     max_result_chars: int = 120_000
     extra_tools: tuple[str, ...] = field(default_factory=tuple)
-    """Individual tools to add on top of the selected toolsets."""
+    """Individual tools to add on top of the selected toolsets.
+
+    Naming a tool here also exempts it from `read_only`, which is the point: it is
+    how an otherwise read-only server is allowed to save a draft without also being
+    allowed to send one.
+    """
 
     # ------------------------------------------------------------------ parsing
 
@@ -129,9 +134,7 @@ class Settings:
             profile=os.environ.get("TBMCP_PROFILE") or None,
             default_timeout=float(os.environ.get("TBMCP_TIMEOUT", "30") or 30),
             autostart_daemon=not cls._flag("TBMCP_NO_AUTOSTART", False),
-            extra_tools=tuple(
-                t.strip() for t in (os.environ.get("TBMCP_TOOLS") or "").split(",") if t.strip()
-            ),
+            extra_tools=parse_tools(os.environ.get("TBMCP_TOOLS")),
         )
 
     def merged_with(self, **overrides: object) -> Settings:
@@ -159,6 +162,20 @@ class Settings:
             f"{name} is outside the reviewed preference allowlist. Start the server with "
             "--unsafe-prefs to permit it."
         )
+
+
+def parse_tools(raw: str | None) -> tuple[str, ...]:
+    """`"mail_draft_save,mail_compose_open"` -> the names, de-duplicated in order.
+
+    Unlike toolsets these cannot be validated here — which tools exist is only known
+    once the modules are imported — so `build_server` reports an unknown name.
+    """
+    seen: list[str] = []
+    for token in (raw or "").split(","):
+        name = token.strip()
+        if name and name not in seen:
+            seen.append(name)
+    return tuple(seen)
 
 
 def parse_toolsets(raw: str | None) -> tuple[str, ...]:

--- a/src/tbmcp/safety.py
+++ b/src/tbmcp/safety.py
@@ -18,7 +18,9 @@ anything else gets a `BlockedError` that tells the model exactly what to pass.
 
 from __future__ import annotations
 
+import functools
 from collections.abc import Callable
+from contextvars import ContextVar
 from typing import Annotated, Any
 
 from mcp.server.mcpserver import Context, Elicit, Resolve
@@ -117,13 +119,42 @@ def Gate(action: str) -> Any:
     return Annotated[Consent, Resolve(consent_for(action))]
 
 
+#: Set for the duration of a tool the operator named in `--tools`. Read-only is a
+#: blanket policy and naming one tool by hand is the deliberate exception to it, but
+#: the exception has to reach `guard_write`, which runs deep inside a tool body and
+#: has no idea which tool it is guarding.
+#:
+#: A ContextVar rather than a field on `_settings`: tool calls share one process and
+#: interleave at every await, so toggling global state around one call would leak its
+#: exemption into whatever else happened to be in flight.
+_exempt_from_read_only: ContextVar[bool] = ContextVar("tbmcp_write_exempt", default=False)
+
+
+def exempt_write(fn: Callable[..., Any]) -> Callable[..., Any]:
+    """Wrap a tool named in `--tools` so `guard_write` lets its writes through."""
+
+    @functools.wraps(fn)
+    async def permitted(*args: Any, **kwargs: Any) -> Any:
+        token = _exempt_from_read_only.set(True)
+        try:
+            return await fn(*args, **kwargs)
+        finally:
+            _exempt_from_read_only.reset(token)
+
+    return permitted
+
+
 def guard_write(what: str) -> None:
-    """Refuse a mutating operation when the server was started read-only."""
-    if _settings.read_only:
+    """Refuse a mutating operation when the server was started read-only.
+
+    The exception is a tool the operator named in `--tools`, which is how you allow
+    one write — saving a draft, say — without lifting read-only for everything else.
+    """
+    if _settings.read_only and not _exempt_from_read_only.get():
         raise BlockedError(
             f"This server is running read-only, so it will not {what}.",
             code="READ_ONLY",
-            needs="restart without --read-only",
+            needs="restart without --read-only, or --tools <name> to allow just this one",
         )
 
 

--- a/src/tbmcp/server.py
+++ b/src/tbmcp/server.py
@@ -55,6 +55,15 @@ class Registrar:
         self.settings = settings
         self.registered: list[str] = []
         self.skipped: list[str] = []
+        self.named = frozenset(settings.extra_tools)
+        """Tools the operator asked for by name, whatever the toolset selection says."""
+        self.exempted: list[str] = []
+        """Named tools that read-only would otherwise have dropped."""
+        self.found: set[str] = set()
+        """Which named tools actually exist, so a typo can be reported rather than ignored."""
+        self.toolset_selected = True
+        """False while a module is imported only to reach one named tool inside it.
+        Its other tools must not be registered as a side effect of that import."""
 
     def _add(
         self,
@@ -65,11 +74,24 @@ class Registrar:
         meta: dict[str, Any] | None,
         mutates: bool,
     ) -> F:
-        if mutates and self.settings.read_only:
-            self.skipped.append(fn.__name__)
+        name = fn.__name__
+        named = name in self.named
+        if named:
+            self.found.add(name)
+        elif not self.toolset_selected:
             return fn
+        registered: F = fn
+        if mutates and self.settings.read_only:
+            if not named:
+                self.skipped.append(name)
+                return fn
+            # Named by hand, so read-only yields for this one tool. The decision has
+            # to be carried into the call: `guard_write` runs inside the body and
+            # cannot see that this tool was singled out.
+            registered = safety.exempt_write(fn)  # type: ignore[assignment]
+            self.exempted.append(name)
         self.mcp.add_tool(
-            fn,
+            registered,
             title=title,
             # Normalise the docstring ourselves rather than letting the interpreter
             # decide: CPython 3.13 strips common leading whitespace from `__doc__` at
@@ -79,7 +101,7 @@ class Registrar:
             annotations=annotations,
             meta=meta or None,
         )
-        self.registered.append(fn.__name__)
+        self.registered.append(name)
         return fn
 
     def read_tool(
@@ -150,22 +172,46 @@ def build_server(settings: Settings, *, bridge: Bridge | None = None) -> MCPServ
     )
     registrar = Registrar(mcp, settings)
 
+    # A named tool may live in a toolset that was not selected, and nothing outside a
+    # toolset module knows which tools it defines. So once `--tools` is in play every
+    # toolset is imported and the Registrar drops whatever was not asked for.
     for name in ALL_TOOLSETS:
-        if name not in settings.toolsets:
+        selected = name in settings.toolsets
+        if not selected and not registrar.named:
             continue
         module = importlib.import_module(f".tools.{name}", package=__package__)
         register = getattr(module, "register", None)
         if register is None:
             log.warning("toolset %s has no register()", name)
             continue
+        registrar.toolset_selected = selected
         register(registrar)
+    registrar.toolset_selected = True
+
+    unknown = sorted(registrar.named - registrar.found)
+    if unknown:
+        # Loud, because the failure is otherwise invisible: the server starts, the
+        # tool the operator asked for is simply absent, and the model reports that
+        # Thunderbird cannot do the thing.
+        raise SystemExit(
+            f"unknown tool(s) in --tools: {', '.join(unknown)}. "
+            "Run `tbmcp tools --toolsets all` for the available names."
+        )
 
     log.info(
-        "registered %d tools from %s%s",
+        "registered %d tools from %s%s%s",
         len(registrar.registered),
         ",".join(settings.toolsets),
+        f" (+{','.join(sorted(registrar.named))} by name)" if registrar.named else "",
         f" ({len(registrar.skipped)} write tools omitted: read-only)" if registrar.skipped else "",
     )
+    if registrar.exempted:
+        # Worth a WARNING and not an INFO: --read-only no longer means what it says,
+        # and the operator should be able to find out why from the log alone.
+        log.warning(
+            "read-only lifted for %s (named explicitly with --tools)",
+            ", ".join(sorted(registrar.exempted)),
+        )
     return mcp
 
 

--- a/tests/test_bootstrap_run.py
+++ b/tests/test_bootstrap_run.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import shlex
 import sys
 
 import pytest
@@ -12,6 +13,7 @@ import pytest
 from tbmcp.bootstrap import (
     Options,
     _detected_clients,
+    _rerun_without_dry_run,
     _step_addon,
     _step_clients,
     _step_imports,
@@ -635,6 +637,30 @@ def test_no_remedy_ever_names_a_bare_tbmcp_or_pip(step_name):
 
 
 # ------------------------------------------------------------------- I5: no unhandled crash
+
+
+@pytest.mark.parametrize(
+    ("field", "flag"),
+    [("tools", "--tools"), ("toolsets", "--toolsets")],
+)
+def test_the_rerun_command_survives_a_value_with_whitespace(field, flag):
+    """A dry run's whole product is the command it tells you to run next, and both of
+    these flags accept whitespace their parsers then strip — `--tools "a, b"` is valid
+    input. Rendered bare it becomes two arguments, so the command a dry run hands back
+    fails in a way that looks like the tool is broken rather than the quoting.
+
+    `shlex.split` is the check rather than a substring match: the question is not what
+    the string looks like, it is what a shell does with it.
+    """
+    value = "mail_draft_save, mail_compose_open" if field == "tools" else "mail, folders"
+    command = _rerun_without_dry_run(Options(**{field: value}))
+
+    argv = shlex.split(command)
+    assert flag in argv, argv
+    assert argv[argv.index(flag) + 1] == value, (
+        f"{flag} lost its value to shell word-splitting: {argv}"
+    )
+    assert argv[-1] == value, f"a stray positional trailed the command: {argv}"
 
 
 def test_a_steps_own_bug_still_produces_valid_json_not_a_traceback():

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -46,7 +46,7 @@ def test_doctor_ok_true_when_admin_toolset_deselected_and_bridge_is_healthy():
     """
     report = {
         "bridge": {"connected": True},
-        "tbStatusCall": {"skipped": "admin toolset not selected; tb_status is not registered"},
+        "tbStatusCall": {"skipped": "tb_status is not registered"},
     }
     assert _doctor_ok(report) is True
 
@@ -56,7 +56,7 @@ def test_doctor_ok_false_when_admin_deselected_but_bridge_is_not_connected():
     genuinely disconnected bridge."""
     report = {
         "bridge": {"connected": False},
-        "tbStatusCall": {"skipped": "admin toolset not selected; tb_status is not registered"},
+        "tbStatusCall": {"skipped": "tb_status is not registered"},
     }
     assert _doctor_ok(report) is False
 
@@ -80,6 +80,29 @@ def _clean_tbmcp_env(monkeypatch):
         "TBMCP_TOOLS",
     ):
         monkeypatch.delenv(var, raising=False)
+
+
+class FakeMCP:
+    """Stands in for the built server.
+
+    `cmd_doctor` asks it what is registered before deciding whether to probe, so a
+    test says which tools exist rather than the fake re-deriving it from settings —
+    re-deriving would mean the fake and the code under test could agree while both
+    being wrong.
+    """
+
+    def __init__(self, tools: list[str], *, record: list | None = None, connected: bool = True):
+        self._tools = tools
+        self._record = record
+        self._connected = connected
+
+    async def list_tools(self):
+        return [SimpleNamespace(name=name) for name in self._tools]
+
+    async def call_tool(self, name, args):
+        if self._record is not None:
+            self._record.append(name)
+        return SimpleNamespace(structured_content={"connected": self._connected})
 
 
 def _stub_common(monkeypatch, *, bridge_status: dict) -> tuple[list, list]:
@@ -130,13 +153,9 @@ def test_no_start_reuses_the_one_bridge_and_never_autostarts_a_second(monkeypatc
     created_bridges = _stub_common(monkeypatch, bridge_status={"connected": True})
     build_server_calls: list = []
 
-    class FakeMCP:
-        async def call_tool(self, name, args):
-            return SimpleNamespace(structured_content={"connected": True})
-
     def fake_build_server(settings, *, bridge=None):
         build_server_calls.append(bridge)
-        return FakeMCP()
+        return FakeMCP(["tb_status"])
 
     monkeypatch.setattr("tbmcp.server.build_server", fake_build_server)
 
@@ -167,14 +186,9 @@ def test_admin_toolset_deselected_does_not_dispatch_tb_status_and_still_reports_
     call_tool_invocations: list = []
     build_server_settings: list = []
 
-    class FakeMCP:
-        async def call_tool(self, name, args):
-            call_tool_invocations.append(name)
-            return SimpleNamespace(structured_content={"connected": True})
-
     def fake_build_server(settings, *, bridge=None):
         build_server_settings.append(settings)
-        return FakeMCP()
+        return FakeMCP([], record=call_tool_invocations)
 
     monkeypatch.setattr("tbmcp.server.build_server", fake_build_server)
 
@@ -190,15 +204,48 @@ def test_admin_toolset_deselected_does_not_dispatch_tb_status_and_still_reports_
 
 
 @pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_tb_status_named_with_tools_is_probed_even_without_the_admin_toolset(monkeypatch):
+    """`--tools tb_status` registers the tool with `admin` deselected, so deciding the
+    probe on toolset membership skipped a tool that was really there — and `_doctor_ok`
+    treats a skip as "not a broken chain". `doctor` therefore reported a healthy chain
+    it had never exercised, and `bootstrap`'s verify step said the check had not run.
+
+    The probe now keys off what the server actually registered.
+    """
+    _stub_common(monkeypatch, bridge_status={"connected": True})
+    call_tool_invocations: list = []
+    build_server_settings: list = []
+
+    def fake_build_server(settings, *, bridge=None):
+        build_server_settings.append(settings)
+        return FakeMCP(["tb_status"], record=call_tool_invocations)
+
+    monkeypatch.setattr("tbmcp.server.build_server", fake_build_server)
+
+    args = build_parser().parse_args(
+        ["doctor", "--json", "--toolsets", "mail", "--tools", "tb_status"]
+    )
+    exit_code = cmd_doctor(args)
+
+    settings = build_server_settings[0]
+    assert "admin" not in settings.toolsets
+    assert settings.extra_tools == ("tb_status",)
+    assert call_tool_invocations == ["tb_status"], (
+        "a tool named in --tools is registered, so doctor must actually exercise it "
+        "rather than reporting success on a check it skipped"
+    )
+    assert exit_code == 0
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
 def test_returns_nonzero_when_the_bridge_is_genuinely_not_connected(monkeypatch):
     """Sanity check on the other side of item 4: a real problem must still fail."""
     _stub_common(monkeypatch, bridge_status={"connected": False})
 
-    class FakeMCP:
-        async def call_tool(self, name, args):
-            return SimpleNamespace(structured_content={"connected": False})
-
-    monkeypatch.setattr("tbmcp.server.build_server", lambda settings, *, bridge=None: FakeMCP())
+    monkeypatch.setattr(
+        "tbmcp.server.build_server",
+        lambda settings, *, bridge=None: FakeMCP(["tb_status"], connected=False),
+    )
 
     args = build_parser().parse_args(["doctor", "--json"])
     exit_code = cmd_doctor(args)

--- a/tests/test_named_tools.py
+++ b/tests/test_named_tools.py
@@ -175,3 +175,22 @@ def test_named_tools_survive_into_a_client_config() -> None:
 def test_a_plain_config_gains_no_tools_flag() -> None:
     _, args = clients.server_command(Settings())
     assert "--tools" not in args
+
+
+# ------------------------------------------------------------------------ CLI wiring
+
+
+@pytest.mark.parametrize("subcommand", ["serve", "doctor", "setup", "tools", "bootstrap"])
+def test_tools_is_a_real_flag_wherever_toolsets_is(subcommand: str) -> None:
+    """argparse accepts any unambiguous prefix, and `--tools` is a prefix of
+    `--toolsets`. A subparser that has one and not the other therefore does not
+    reject `--tools mail_draft_save` — it silently reads it as a toolset named
+    `mail_draft_save`, which fails later in a different command, or on a dry run gets
+    printed back as the command to rerun. Nothing about the failure points at the
+    flag that caused it.
+    """
+    from tbmcp.cli import build_parser
+
+    args = build_parser().parse_args([subcommand, "--tools", "mail_draft_save"])
+    assert getattr(args, "tools", None) == "mail_draft_save"
+    assert getattr(args, "toolsets", None) is None, "swallowed as an abbreviation"

--- a/tests/test_named_tools.py
+++ b/tests/test_named_tools.py
@@ -1,0 +1,177 @@
+"""`--tools`: registering individual tools on top of a toolset selection.
+
+The motivating case is drafting. `mail_draft_save` produces something reviewable and
+deletable that never leaves the machine, but it lives in `compose` beside three tools
+that do put mail on the wire, and toolsets are all or nothing — so wanting a draft
+meant registering `mail_send` too, and a read-only server could not have either.
+
+Naming a tool is the way out, and it has to carry a read-only exemption: a tool that
+is registered and then always refuses is worse than one that was never there, because
+the model tries it first and reports the failure as Thunderbird's.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from mcp import Client
+
+from tbmcp import clients, safety
+from tbmcp.config import Settings, parse_tools
+from tbmcp.errors import BlockedError
+from tbmcp.safety import guard_write
+from tbmcp.server import build_server
+
+pytestmark = pytest.mark.anyio
+
+#: The posture this feature exists to make possible: read everything, draft, send
+#: nothing.
+READING = ("mail", "folders", "search")
+DRAFTING = ("mail_draft_save", "mail_compose_open", "mail_send_status")
+OUTBOUND = ("mail_send", "mail_reply", "mail_forward")
+
+
+def _settings(**overrides) -> Settings:
+    return Settings().merged_with(**{"toolsets": READING, "read_only": True, **overrides})
+
+
+async def _names(settings: Settings) -> set[str]:
+    return {tool.name for tool in await build_server(settings).list_tools()}
+
+
+def _text(result) -> str:
+    return " ".join(getattr(block, "text", "") for block in result.content)
+
+
+# ----------------------------------------------------------------------- parsing
+
+
+def test_parse_tools_strips_and_dedupes_in_order() -> None:
+    assert parse_tools(" a , b ,, a ,c ") == ("a", "b", "c")
+    assert parse_tools(None) == ()
+    assert parse_tools("") == ()
+
+
+# ------------------------------------------------------------------ registration
+
+
+async def test_drafting_can_be_enabled_without_sending() -> None:
+    """The headline case, stated as the property that matters: everything that puts
+    mail on the wire stays absent. A model cannot call what was never advertised,
+    which is a stronger guarantee than a confirmation gate it fills in itself."""
+    names = await _names(_settings(extra_tools=DRAFTING))
+    assert set(DRAFTING) <= names
+    for outbound in OUTBOUND:
+        assert outbound not in names, f"{outbound} registered; drafting must not imply sending"
+
+
+async def test_naming_a_tool_does_not_drag_in_its_neighbours() -> None:
+    """`compose` has to be imported to reach `mail_draft_save`, and importing a
+    toolset module runs the whole of its `register()`. Everything it defines that
+    nobody asked for has to be dropped on the way past."""
+    base = await _names(_settings())
+    named = await _names(_settings(extra_tools=("mail_draft_save",)))
+    assert named - base == {"mail_draft_save"}
+
+
+async def test_a_named_tool_can_come_from_an_unselected_toolset() -> None:
+    names = await _names(_settings(toolsets=("mail",), extra_tools=("contact_search",)))
+    assert "contact_search" in names
+    assert "contact_delete" not in names
+
+
+async def test_an_unknown_name_is_refused_at_startup() -> None:
+    """Silence would be the worst outcome: the server starts, the tool is simply
+    missing, and the model reports that Thunderbird cannot do the thing."""
+    with pytest.raises(SystemExit) as caught:
+        build_server(_settings(extra_tools=("mail_draft_sav",)))
+    assert "mail_draft_sav" in str(caught.value)
+
+
+async def test_a_named_write_tool_is_still_advertised_as_writing() -> None:
+    """`test_read_only_registers_nothing_that_writes` is the rule and this is its
+    one documented exception. The exemption changes what gets registered, never what
+    the client is told about it — a host that prompts on `destructive_hint` must go
+    on seeing the truth."""
+    server = build_server(_settings(extra_tools=("mail_draft_save",)))
+    tool = next(t for t in await server.list_tools() if t.name == "mail_draft_save")
+    assert tool.annotations is not None
+    assert tool.annotations.read_only_hint is False
+    # Saving a draft is a local write and nothing more; it must not be dressed up as
+    # one, or a host will prompt for it as though mail were leaving.
+    assert tool.annotations.destructive_hint is False
+    assert tool.annotations.open_world_hint is False
+
+
+# ---------------------------------------------------------------- the exemption
+
+
+async def test_a_named_write_tool_actually_writes_under_read_only(fake_bridge) -> None:
+    """Registering it is only half the job. `guard_write` runs inside the tool body
+    and would otherwise refuse the very call it was just registered to allow."""
+    bridge = fake_bridge({"compose.save": {"id": 7, "folderId": "account1://Drafts"}})
+    server = build_server(_settings(extra_tools=("mail_draft_save",)), bridge=bridge)
+    async with Client(server) as client:
+        result = await client.call_tool(
+            "mail_draft_save", {"subject": "Re: invoice", "body": "Thanks — paid today."}
+        )
+    assert not result.is_error, _text(result)
+    assert bridge.methods() == ["compose.save"]
+
+
+async def test_the_exemption_is_scoped_to_the_call_that_owns_it() -> None:
+    """A ContextVar rather than a flag on the settings, and this is why: tool calls
+    share one process and interleave at every await, so a global toggle would hand
+    one call's exemption to whatever else happened to be in flight."""
+    safety.set_settings(Settings(read_only=True))
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    @safety.exempt_write
+    async def save_a_draft() -> str:
+        guard_write("save drafts")
+        entered.set()
+        await release.wait()
+        guard_write("save drafts")  # still permitted on the far side of the await
+        return "saved"
+
+    task = asyncio.create_task(save_a_draft())
+    await entered.wait()
+
+    with pytest.raises(BlockedError) as caught:
+        guard_write("delete messages")  # a different call, concurrent with the draft
+    assert caught.value.code == "READ_ONLY"
+
+    release.set()
+    assert await task == "saved"
+
+    # And it is gone again once the call that owned it has finished.
+    with pytest.raises(BlockedError):
+        guard_write("save drafts")
+
+
+async def test_the_refusal_names_the_flag_that_would_allow_one_tool() -> None:
+    """A model told only "restart without --read-only" will propose lifting the whole
+    policy. The narrower fix is the one worth naming."""
+    safety.set_settings(Settings(read_only=True))
+    with pytest.raises(BlockedError) as caught:
+        guard_write("save drafts")
+    assert "--tools" in caught.value.needs[0]
+
+
+# ----------------------------------------------------------------- config round trip
+
+
+def test_named_tools_survive_into_a_client_config() -> None:
+    """`tbmcp setup` regenerates the client config from Settings. A name dropped here
+    is a server that silently loses its drafting tools the next time it is
+    registered — and nothing about the resulting config looks wrong."""
+    _, args = clients.server_command(_settings(extra_tools=DRAFTING))
+    assert "--tools" in args, args
+    assert args[args.index("--tools") + 1] == ",".join(DRAFTING)
+    assert "--read-only" in args
+
+
+def test_a_plain_config_gains_no_tools_flag() -> None:
+    _, args = clients.server_command(Settings())
+    assert "--tools" not in args


### PR DESCRIPTION
`extra_tools` has been in `Settings` since 1.0 — parsed from `TBMCP_TOOLS`, documented as *"Individual tools to add on top of the selected toolsets"* — but `build_server` never read it and no CLI flag set it, so it did nothing. This finishes it and gives it `--tools`.

## Why

A toolset is all or nothing, which is coarse when a single tool inside a group is the one you want. The case that made me reach for it: letting an agent draft mail without letting it send any.

`mail_draft_save` produces something reviewable and deletable that never leaves the machine — but it ships in `compose` beside `mail_send`, `mail_reply` and `mail_forward`. So drafting meant registering three tools that put mail on the wire, and `--read-only` meant having none of them.

```bash
tbmcp serve --read-only --toolsets mail,folders,search \
  --tools mail_draft_save,mail_compose_open,mail_send_status
```

18 tools instead of 15, and the three outbound ones stay unregistered. That is a stronger guarantee than the consent gates can give: `confirm` is a parameter the model fills in itself, whereas a model cannot call a tool it was never advertised.

## Decisions worth flagging

**Naming a tool also exempts it from `--read-only`.** It has to. A tool that registers and then always refuses is worse than one that was never there, because the model tries it first and reports the refusal as Thunderbird's.

The exemption rides a `ContextVar` rather than a field on the settings — tool calls share a process and interleave at every await, so a global toggle would hand one call's exemption to whatever else was in flight. There's a test that runs a permitted call and a forbidden one concurrently and holds the line.

If you would rather `--read-only` stayed absolute, the alternative is a separate flag (`--allow-write-tool`) so the weakening is spelled out at the call site. Say the word and I will split it.

**Reaching a named tool means importing a toolset that was not selected,** which runs the whole of its `register()`. The Registrar drops everything nobody asked for, so `--tools contact_search` does not also quietly land `contact_delete`.

**An unknown name is a startup error.** Silence is the bad outcome here: the server starts, the tool is simply absent, and the model reports that Thunderbird cannot do the thing.

**`--tools` round-trips through `clients.server_command`,** so `tbmcp setup` does not regenerate a config that has quietly lost its named tools.

**Annotations are untouched.** A named write tool is still advertised as mutating, so a host that prompts on annotations goes on seeing the truth — the exemption changes what is registered, never what the client is told about it. Startup also logs the lifted tools at WARNING, so `--read-only` no longer meaning quite what it says is visible from the log alone.

## Tests

11 new tests in `tests/test_named_tools.py` covering each of the above, including the concurrency case and the "drafting must not imply sending" property. 205 pass on this branch.

Also verified against a live Thunderbird: the draft really is written, lands in Drafts, is findable by search, and the Outbox count does not move. That harness is profile-specific, so it is not in the PR.

## About the red CI

**CI fails on this branch, and it fails on `main` in exactly the same way** — the same five tests in `test_tools_mail.py`, on every runner:

| | failures on mcp 2.1.1 |
|---|---|
| `main`, untouched | 5 |
| `main` + this PR | the same 5 |

mcp 2.1 wraps an unrecognised exception as `UnexpectedToolError("Error executing tool <name>")` and drops the message, while `pyproject.toml` floors `mcp>=2.0.0,<3`. Nothing in this PR touches that path.

There is a one-line fix for it in #4 (raise `ToolError`, which 2.0 and 2.1 both honour). I deliberately did not duplicate it here rather than ship the same change in two open PRs — but it stands alone and it unbreaks `main`, so if it is useful I am happy to split it into its own PR ahead of both.

## Relation to #4

Independent. This is branched from `main` and shares no commits with #4. If both land they touch one common line in `Registrar._add`, which reconciles trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
