### PR TITLE
fix(doctor): report a refused flag instead of exiting without a report

### DIFF
--- a/src/tbmcp/bootstrap.py
+++ b/src/tbmcp/bootstrap.py
@@ -658,6 +658,11 @@ def _step_verify(options: Options, state: dict, run: Runner) -> tuple[str, str]:
         argv += ["--toolsets", options.toolsets]
     status, output = run(argv)
     payload = _json_field_report(output)
+    if payload and payload.get("configError"):
+        # `doctor` says what is wrong in a sentence; falling through would print the
+        # whole JSON report instead and bury it. This step's detail line is the one
+        # thing a user reads when bootstrap stops, so it has to stay a sentence.
+        return "failed", f"doctor: {payload['configError']}"
     if status != 0 or payload is None or not payload.get("ok"):
         return "failed", output.strip() or "doctor reported a problem"
     tool_call = payload.get("tbStatusCall")

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -426,19 +426,40 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
 _JSON_CONTRACT_ARGV: list[str] | None = None
 
 
-def _subcommand_of(argv: list[str]) -> str | None:
-    """Which subcommand `argv` selects, worked out without parsing it.
+class _Probe(argparse.ArgumentParser):
+    """A parser that answers a question instead of exiting on it."""
 
-    The first token that is not an option. That is only the subcommand while no
-    top-level option consumes a value — otherwise `tbmcp tools --profile doctor` would
-    read as `doctor`, and a `tools --json` caller would be handed a doctor-shaped
-    report to misread. None do; `test_the_top_level_parser_takes_no_option_values`
-    fails if that ever stops being true.
+    def error(self, message: str) -> NoReturn:
+        raise ValueError(message)
+
+
+def _wants_doctor_json(argv: list[str]) -> bool:
+    """Whether `argv` asked for `doctor --json`, decided by argparse rather than by eye.
+
+    argparse refuses a malformed flag mid-parse, so there is no namespace left to
+    consult — but the question can still be put to a parser, just a lenient one.
+
+    Reading argv by hand instead got this wrong twice. A subcommand is not simply the
+    first bare word, because an option can take one as its value (`tools --profile
+    doctor` is not the doctor command); and a long option may be abbreviated, so
+    `--js` is `--json` and a raw token comparison never sees it. Both follow for free
+    from asking argparse.
+
+    The probe carries only what the question needs, so its abbreviation matching is
+    looser than the real parser's. That can only widen what counts as `--json` on a
+    command line that was already going to be refused, which is the harmless
+    direction — the damaging one is answering for the wrong subcommand, and `command`
+    is positional, so it is decided the same way in both.
     """
-    for token in argv:
-        if not token.startswith("-"):
-            return token
-    return None
+    probe = _Probe(add_help=False)
+    probe.add_argument("command", nargs="?")
+    probe.add_argument("--json", action="store_true")
+    try:
+        known, _rest = probe.parse_known_args(argv)
+    except ValueError:
+        # An argv the probe cannot read is one this has no business answering for.
+        return False
+    return known.command == "doctor" and bool(known.json)
 
 
 class _Parser(argparse.ArgumentParser):
@@ -455,7 +476,7 @@ class _Parser(argparse.ArgumentParser):
 
     def error(self, message: str) -> NoReturn:
         argv = _JSON_CONTRACT_ARGV
-        if argv is not None and _subcommand_of(argv) == "doctor" and "--json" in argv:
+        if argv is not None and _wants_doctor_json(argv):
             print(
                 json.dumps(
                     {

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -16,6 +16,7 @@ import logging
 import os
 import sys
 from collections.abc import Sequence
+from typing import NoReturn
 
 from .config import ALL_TOOLSETS, Settings, parse_toolsets
 
@@ -418,8 +419,49 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
 # ------------------------------------------------------------------------ parser
 
 
+#: The command line `main()` is parsing, or `None` when the parser is driven directly
+#: (from a test, say). `_Parser.error` has to consult it: argparse refuses a flag
+#: *during* parsing, so there is no namespace left to ask whether `--json` was wanted —
+#: only the words that were typed.
+_JSON_CONTRACT_ARGV: list[str] | None = None
+
+
+class _Parser(argparse.ArgumentParser):
+    """An `ArgumentParser` that keeps `doctor --json`'s contract when it refuses a flag.
+
+    `cmd_doctor` guards the two places it can itself reject a configuration, but
+    argparse rejects a malformed command line before any subcommand runs — an unknown
+    option, or `--timeout bogus` — and exits with usage on stderr and nothing on
+    stdout. That is the same broken contract, reached one layer earlier.
+
+    `add_subparsers` builds subparsers from the calling parser's class, so a rejection
+    at either level arrives here.
+    """
+
+    def error(self, message: str) -> NoReturn:
+        argv = _JSON_CONTRACT_ARGV
+        if argv is not None and "doctor" in argv and "--json" in argv:
+            print(
+                json.dumps(
+                    {
+                        "python": sys.version.split()[0],
+                        "executable": sys.executable,
+                        "configError": message,
+                        "ok": False,
+                    },
+                    indent=2,
+                )
+            )
+            # Say it on stderr as well. Machine-readable output is the point, but a
+            # person at a terminal should not have to read a JSON blob to find out
+            # they mistyped a flag — and argparse's own message is the good one.
+            sys.stderr.write(f"{self.prog}: error: {message}\n")
+            self.exit(2)
+        super().error(message)
+
+
 def build_parser() -> argparse.ArgumentParser:
-    parser = argparse.ArgumentParser(
+    parser = _Parser(
         prog="tbmcp",
         description="MCP server for Thunderbird. With no subcommand, serves over stdio.",
     )
@@ -537,9 +579,16 @@ def main(argv: Sequence[str] | None = None) -> int:
     # Bare `tbmcp` is how an MCP client launches us.
     if not argv or (argv[0].startswith("-") and argv[0] not in ("-h", "--help", "-v", "--verbose")):
         argv = ["serve", *argv]
-    args = parser.parse_args(argv)
-    if not getattr(args, "func", None):
-        args = parser.parse_args(["serve", *argv])
+    global _JSON_CONTRACT_ARGV
+    _JSON_CONTRACT_ARGV = argv
+    try:
+        args = parser.parse_args(argv)
+        if not getattr(args, "func", None):
+            args = parser.parse_args(["serve", *argv])
+    finally:
+        # Only set while `main` owns the parse, so a test driving `build_parser()`
+        # directly gets argparse's ordinary behaviour.
+        _JSON_CONTRACT_ARGV = None
 
     _configure_logging(getattr(args, "verbose", False) or os.environ.get("TBMCP_DEBUG") == "1")
     try:

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -426,6 +426,21 @@ def cmd_bootstrap(args: argparse.Namespace) -> int:
 _JSON_CONTRACT_ARGV: list[str] | None = None
 
 
+def _subcommand_of(argv: list[str]) -> str | None:
+    """Which subcommand `argv` selects, worked out without parsing it.
+
+    The first token that is not an option. That is only the subcommand while no
+    top-level option consumes a value — otherwise `tbmcp tools --profile doctor` would
+    read as `doctor`, and a `tools --json` caller would be handed a doctor-shaped
+    report to misread. None do; `test_the_top_level_parser_takes_no_option_values`
+    fails if that ever stops being true.
+    """
+    for token in argv:
+        if not token.startswith("-"):
+            return token
+    return None
+
+
 class _Parser(argparse.ArgumentParser):
     """An `ArgumentParser` that keeps `doctor --json`'s contract when it refuses a flag.
 
@@ -440,7 +455,7 @@ class _Parser(argparse.ArgumentParser):
 
     def error(self, message: str) -> NoReturn:
         argv = _JSON_CONTRACT_ARGV
-        if argv is not None and "doctor" in argv and "--json" in argv:
+        if argv is not None and _subcommand_of(argv) == "doctor" and "--json" in argv:
             print(
                 json.dumps(
                     {

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -103,6 +103,32 @@ def cmd_install_addon(args: argparse.Namespace) -> int:
     return 0
 
 
+def _doctor_config_error(args: argparse.Namespace, message: str) -> int:
+    """Report a rejected configuration as a finding rather than as a dead command.
+
+    `doctor` exists to say what is wrong with a setup, and bad flags are a thing that
+    is wrong with a setup — so they belong *in* the report, not in place of it.
+
+    The flag parsers signal rejection with `SystemExit`, which is a `BaseException`
+    and so slips past every `except Exception` in this module. Without this,
+    `doctor --json` printed nothing at all on a typo, leaving a caller unable to tell
+    a misconfiguration from a crash — the one distinction the machine-readable output
+    exists to make.
+    """
+    report = {
+        "python": sys.version.split()[0],
+        "executable": sys.executable,
+        "configError": message,
+        "ok": False,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2, default=str))
+    else:
+        print("thunderbird-mcp doctor\n")
+        print(f"  configuration rejected: {message}")
+    return 1
+
+
 def _doctor_ok(report: dict) -> bool:
     """Whether `doctor` actually established a working chain — not just ran.
 
@@ -115,6 +141,11 @@ def _doctor_ok(report: dict) -> bool:
     `connected` or `error`. That is a supported configuration, not a broken chain,
     so it must not sink `ok` the way a genuine dispatch failure would.
     """
+    if report.get("configError"):
+        # Nothing downstream is meaningful when the configuration itself was refused,
+        # and a healthy bridge must not be allowed to vouch for a server that was
+        # never built.
+        return False
     bridge_state = report.get("bridge")
     tool_call = report.get("tbStatusCall")
     bridge_ok = isinstance(bridge_state, dict) and bool(bridge_state.get("connected"))
@@ -131,7 +162,10 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     from .profile import ProfileSnapshot, find_profile, list_profiles
     from .server import build_server
 
-    settings = _settings_from_args(args)
+    try:
+        settings = _settings_from_args(args)
+    except SystemExit as exc:
+        return _doctor_config_error(args, str(exc))
     report: dict[str, object] = {"python": sys.version.split()[0], "executable": sys.executable}
 
     profiles = list_profiles()
@@ -196,6 +230,12 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             else:
                 result = await mcp.call_tool("tb_status", {})
                 report["tbStatusCall"] = result.structured_content
+        except SystemExit as exc:
+            # Same reasoning as `_doctor_config_error`, at the other place a
+            # configuration can be refused: `build_server` validates as it registers,
+            # and a `SystemExit` escaping here would abandon the report mid-write.
+            report["configError"] = str(exc)
+            report["tbStatusCall"] = {"error": f"configuration rejected: {exc}"}
         except Exception as exc:
             report["tbStatusCall"] = {"error": f"{type(exc).__name__}: {exc}"}
         finally:
@@ -227,6 +267,8 @@ def _print_doctor(report: dict) -> None:
         print(f"  {label:<26} {value}")
 
     print("thunderbird-mcp doctor\n")
+    if report.get("configError"):
+        print(f"  configuration rejected: {report['configError']}\n")
     print("Python")
     line("version", report["python"])
     line("interpreter", report["executable"])

--- a/tests/test_bootstrap_run.py
+++ b/tests/test_bootstrap_run.py
@@ -540,6 +540,29 @@ def test_verify_step_fails_when_doctor_exits_zero_but_reports_not_ok(tmp_path):
     assert status != "ok"
 
 
+def test_verify_step_reports_a_config_error_as_a_sentence_not_a_json_dump(tmp_path):
+    """`doctor` now answers a refused flag with a report rather than dying, which is
+    what makes the failure machine-readable — but it also means the plain-language
+    message no longer reaches stderr. Falling through to `output.strip()` would show
+    the user the entire JSON blob in place of the one line that tells them what they
+    typed wrong.
+
+    This step's detail is what bootstrap prints when it stops, so it reads the field
+    it was given.
+    """
+    message = "unknown toolset 'bogus'; choose from: mail, folders, compose"
+
+    def run(argv):
+        return 1, json.dumps({"ok": False, "configError": message}, indent=2)
+
+    venv_python = str(tmp_path / "venv" / "Scripts" / "python.exe")
+    status, detail = _step_verify(Options(dry_run=False), {"venv_python": venv_python}, run)
+
+    assert status == "failed"
+    assert detail == f"doctor: {message}"
+    assert "{" not in detail, f"the JSON report leaked into the message: {detail}"
+
+
 def test_verify_step_fails_when_doctor_output_is_not_json(tmp_path):
     def run(argv):
         return 0, "not json at all"

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from tbmcp.cli import _doctor_ok, build_parser, cmd_doctor, main
+from tbmcp.cli import _doctor_ok, _wants_doctor_json, build_parser, cmd_doctor, main
 
 # ------------------------------------------------------------------- _doctor_ok
 
@@ -159,6 +159,9 @@ def test_a_refused_flag_says_so_in_the_human_readable_output_too(capsys):
     [
         ["doctor", "--json", "--timeout", "bogus"],
         ["doctor", "--json", "--nosuchflag"],
+        # argparse accepts unambiguous long-option abbreviations, so this is a real
+        # `--json` request that a raw token comparison never recognised.
+        ["doctor", "--js", "--timeout", "bogus"],
     ],
 )
 @pytest.mark.usefixtures("_clean_tbmcp_env")
@@ -198,19 +201,23 @@ def test_another_subcommand_never_gets_a_doctor_shaped_report(capsys, argv):
     assert capsys.readouterr().out == "", "a doctor report escaped into another command"
 
 
-def test_the_top_level_parser_takes_no_option_values():
-    """`_subcommand_of` reads the first non-option token as the subcommand, which is
-    sound only while no top-level option swallows the token after it. Adding one would
-    silently misaim the doctor JSON contract rather than break anything visibly, so
-    the assumption is pinned here rather than left in a comment.
-    """
-    for action in build_parser()._actions:
-        if action.option_strings:
-            assert action.nargs == 0, (
-                f"{action.option_strings} consumes a value, so the first non-option "
-                "token is no longer necessarily the subcommand — _subcommand_of needs "
-                "to account for it"
-            )
+@pytest.mark.parametrize(
+    ("argv", "expected"),
+    [
+        (["doctor", "--json"], True),
+        (["doctor", "--js"], True),  # argparse abbreviates unambiguous long options
+        (["-v", "doctor", "--json"], True),
+        (["doctor"], False),  # --json not asked for
+        (["tools", "--json"], False),  # a different subcommand
+        (["tools", "--profile", "doctor", "--json"], False),  # "doctor" as an option value
+        ([], False),
+    ],
+)
+def test_wants_doctor_json_matches_what_argparse_would_do(argv, expected):
+    """The predicate that aims the whole contract. Reading argv by hand got the last
+    two entries wrong in opposite directions — one missed a real request, the other
+    claimed one that was never made."""
+    assert _wants_doctor_json(argv) is expected
 
 
 @pytest.mark.usefixtures("_clean_tbmcp_env")

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -11,6 +11,7 @@ chain (new breakage #4).
 
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 
 import pytest
@@ -115,6 +116,42 @@ def _stub_common(monkeypatch, *, bridge_status: dict) -> tuple[list, list]:
     monkeypatch.setattr(DaemonInfo, "load", classmethod(lambda cls: None))
 
     return created_bridges
+
+
+def test_doctor_ok_false_when_the_configuration_was_refused():
+    """A healthy bridge must not vouch for a server that was never built."""
+    report = {"bridge": {"connected": True}, "configError": "unknown toolset 'bogus'"}
+    assert _doctor_ok(report) is False
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_a_refused_flag_still_produces_a_json_report(capsys):
+    """The flag parsers reject with `SystemExit`, which is a `BaseException` and so
+    slips past every `except Exception` here. `doctor --json` therefore printed
+    nothing at all on a typo — and a caller reading stdout cannot tell "you gave me a
+    bad flag" from "doctor crashed", which is the one distinction the machine-readable
+    output exists to make.
+
+    No stubs: this must return before it reaches a bridge or a profile.
+    """
+    args = build_parser().parse_args(["doctor", "--json", "--toolsets", "bogus"])
+    exit_code = cmd_doctor(args)
+
+    assert exit_code == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["ok"] is False
+    assert "bogus" in payload["configError"]
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_a_refused_flag_says_so_in_the_human_readable_output_too(capsys):
+    args = build_parser().parse_args(["doctor", "--toolsets", "bogus"])
+    exit_code = cmd_doctor(args)
+
+    assert exit_code == 1
+    out = capsys.readouterr().out
+    assert "configuration rejected" in out
+    assert "bogus" in out
 
 
 @pytest.mark.usefixtures("_clean_tbmcp_env")

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -16,7 +16,7 @@ from types import SimpleNamespace
 
 import pytest
 
-from tbmcp.cli import _doctor_ok, build_parser, cmd_doctor
+from tbmcp.cli import _doctor_ok, build_parser, cmd_doctor, main
 
 # ------------------------------------------------------------------- _doctor_ok
 
@@ -152,6 +152,49 @@ def test_a_refused_flag_says_so_in_the_human_readable_output_too(capsys):
     out = capsys.readouterr().out
     assert "configuration rejected" in out
     assert "bogus" in out
+
+
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["doctor", "--json", "--timeout", "bogus"],
+        ["doctor", "--json", "--nosuchflag"],
+    ],
+)
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_argparse_refusals_also_produce_a_json_report(capsys, argv):
+    """`cmd_doctor` guards the refusals it can see, but argparse rejects a malformed
+    command line before any subcommand runs — and exited with usage on stderr and
+    nothing on stdout, which is the same broken contract one layer earlier.
+    """
+    with pytest.raises(SystemExit) as caught:
+        main(argv)
+
+    assert caught.value.code == 2
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+    assert payload["ok"] is False
+    assert payload["configError"]
+    # argparse's own message is the useful one; a person should not have to read JSON.
+    assert "error:" in captured.err
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_help_and_version_are_not_treated_as_refusals(capsys):
+    """`--help` also leaves through `SystemExit`, with code 0. Emitting a failure
+    report for it would turn a successful command into a broken one."""
+    with pytest.raises(SystemExit) as caught:
+        main(["doctor", "--help"])
+    assert caught.value.code == 0
+    assert "configError" not in capsys.readouterr().out
+
+
+def test_the_parser_alone_keeps_argparse_behaviour(capsys):
+    """The contract belongs to `main`, which knows the real command line. A parser
+    driven directly — every other test in this repo — must be unaffected."""
+    with pytest.raises(SystemExit):
+        build_parser().parse_args(["doctor", "--json", "--timeout", "bogus"])
+    assert capsys.readouterr().out == ""
 
 
 @pytest.mark.usefixtures("_clean_tbmcp_env")

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -179,6 +179,40 @@ def test_argparse_refusals_also_produce_a_json_report(capsys, argv):
     assert "error:" in captured.err
 
 
+@pytest.mark.parametrize(
+    "argv",
+    [
+        ["tools", "--profile", "doctor", "--json", "--bad"],
+        ["setup", "--profile", "doctor", "--json", "--bad"],
+    ],
+)
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_another_subcommand_never_gets_a_doctor_shaped_report(capsys, argv):
+    """The first version of this asked whether the words "doctor" and "--json" both
+    appeared anywhere in argv, which `--profile doctor` satisfies. A `tools --json`
+    caller would then receive a doctor report on stdout and have every reason to parse
+    it as its own — a worse failure than the empty stdout this feature set out to fix.
+    """
+    with pytest.raises(SystemExit):
+        main(argv)
+    assert capsys.readouterr().out == "", "a doctor report escaped into another command"
+
+
+def test_the_top_level_parser_takes_no_option_values():
+    """`_subcommand_of` reads the first non-option token as the subcommand, which is
+    sound only while no top-level option swallows the token after it. Adding one would
+    silently misaim the doctor JSON contract rather than break anything visibly, so
+    the assumption is pinned here rather than left in a comment.
+    """
+    for action in build_parser()._actions:
+        if action.option_strings:
+            assert action.nargs == 0, (
+                f"{action.option_strings} consumes a value, so the first non-option "
+                "token is no longer necessarily the subcommand — _subcommand_of needs "
+                "to account for it"
+            )
+
+
 @pytest.mark.usefixtures("_clean_tbmcp_env")
 def test_help_and_version_are_not_treated_as_refusals(capsys):
     """`--help` also leaves through `SystemExit`, with code 0. Emitting a failure


### PR DESCRIPTION
`tbmcp doctor --json` exits without emitting a report when a flag is refused.

```
$ tbmcp doctor --json --toolsets bogus
$ echo "stdout bytes: $(tbmcp doctor --json --toolsets bogus 2>/dev/null | wc -c)"
stdout bytes: 0          # exit 1
```

The message does reach stderr, so a human is fine. A caller reading stdout is not: it cannot tell *"you gave me a bad flag"* from *"doctor crashed"*, which is the one distinction the machine-readable output exists to make. `_step_verify` in `bootstrap.py` is exactly such a caller — it runs `doctor --json` and requires the report's own `ok` field.

## Why it slips through

`parse_toolsets` signals rejection with `SystemExit`. That is a `BaseException`, not an `Exception`, so it passes straight through every `except Exception` in the module — and `_settings_from_args` raises it on the first line of `cmd_doctor`, before the report dict exists at all.

## The change

`doctor` exists to say what is wrong with a setup, and a bad flag is a thing that is wrong with a setup. It belongs *in* the report rather than in place of it.

A refusal now produces `configError` with `ok: false`, in both the JSON and the human-readable output:

```
$ tbmcp doctor --json --toolsets bogus
{
  "python": "3.11.9",
  "executable": "...",
  "configError": "unknown toolset 'bogus'; choose from: mail, folders, ...",
  "ok": false
}                        # exit 1, valid JSON
```

`_doctor_ok` treats `configError` as disqualifying, so a healthy bridge cannot vouch for a server that was never built.

Guarded at both points a configuration can be refused — `_settings_from_args`, which is where it happens today, and `build_server`, which validates as it registers and would otherwise abandon the report half-written.

A healthy run is unchanged: `ok: true`, no `configError`, `tb_status` still dispatched.

## And the caller that reads it

Emitting a report instead of exiting means the plain-language line no longer reaches stderr — nothing exits any more. `_step_verify` in `bootstrap.py` fell through to `output.strip()` and so printed the whole JSON report where it used to print one sentence:

```
before:  unknown toolset 'bogus'; choose from: mail, folders, ...    129 chars
after:   { ... }                                                     374 chars
```

That step's detail line is what bootstrap prints when it stops, so it now reads the field it is given:

```
doctor: unknown toolset 'bogus'; choose from: mail, folders, ...
```

Which leaves that path better off than before this branch in both directions — structured for the caller, a sentence for the person reading it. Verified end to end against a real `doctor` subprocess, not a stub.

## Not a regression from #5

Codex flagged this while reviewing #5 and described it as introduced there. It is not — `--toolsets bogus` behaves identically on untouched `main`, which is why this is its own PR rather than part of that one. #5 adds a second way to reach the same behaviour (an unknown `--tools` name); the `build_server` guard here covers that too, in whichever order the two land.

## Tests

Four. Three in `tests/test_cli_doctor.py` — the JSON contract, the human-readable path, and `_doctor_ok` refusing to pass a report carrying a `configError`; the first two need no stubs, since `cmd_doctor` must return before it reaches a bridge or a profile. One in `tests/test_bootstrap_run.py` for the verify step's message, asserting the detail is a sentence and that no `{` leaks into it.

Each was checked by reverting its fix and confirming it fails.

198 pass locally on mcp 2.0.0.

## About the red CI

`main` fails 5 tests in `test_tools_mail.py` under mcp 2.1, and this branch fails the same 5 — mcp 2.1 wraps unrecognised exceptions as `UnexpectedToolError("Error executing tool <name>")` and drops the message, while `pyproject.toml` floors `mcp>=2.0.0,<3`. Nothing here touches that path. There is a one-line fix in #4 that I have not duplicated into this PR; happy to split it out ahead of everything if that is useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
