### PR TITLE
v1.3.0 — working search, and a bridge that says what is wrong

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        python: ["3.11", "3.13"]
+        python: ["3.11", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v4
@@ -44,6 +44,12 @@ jobs:
       - name: Tests
         run: uv run pytest -q
 
+      - name: Add-on unit tests (node)
+        # The add-on's background and privileged scripts run under node's vm with
+        # fakes for the WebExtension and XPCOM surfaces (tests/js/README.md). Quote
+        # the glob: `node --test <dir>` does not expand on the Windows runner.
+        run: node --test "tests/js/*.test.mjs"
+
       - name: Cross-layer consistency
         # Compares the Python tools, the add-on handlers and the privileged forwarding
         # list, and validates every add-on script. Node is preinstalled on both
@@ -65,7 +71,7 @@ jobs:
         run: uv run python -m tbmcp tools --toolsets all
 
       - uses: actions/upload-artifact@v4
-        if: matrix.os == 'windows-latest' && matrix.python == '3.13'
+        if: matrix.os == 'windows-latest' && matrix.python == '3.14'
         with:
           name: thunderbird-mcp-addon
           path: build/*.xpi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,13 @@ jobs:
         with:
           enable-cache: true
 
+      # Pinned rather than whatever the image ships: the add-on tests need
+      # `node --test` with glob support, and a runner upgrade must not change what
+      # this job means.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
       # A project venv rather than `--system`: Ubuntu's system interpreter is
       # externally managed and refuses installs. `uv run` then picks up .venv on both
       # platforms without any activation dance.
@@ -47,8 +54,14 @@ jobs:
       - name: Add-on unit tests (node)
         # The add-on's background and privileged scripts run under node's vm with
         # fakes for the WebExtension and XPCOM surfaces (tests/js/README.md). Quote
-        # the glob: `node --test <dir>` does not expand on the Windows runner.
-        run: node --test "tests/js/*.test.mjs"
+        # the glob: `node --test <dir>` does not expand on the Windows runner. And a
+        # glob that matches nothing exits 0, so count the files first: a renamed
+        # directory must not disable this layer behind a green tick.
+        shell: bash
+        run: |
+          count=$(ls tests/js/*.test.mjs 2>/dev/null | wc -l)
+          test "$count" -gt 0 || { echo "no add-on test files found"; exit 1; }
+          node --test "tests/js/*.test.mjs"
 
       - name: Cross-layer consistency
         # Compares the Python tools, the add-on handlers and the privileged forwarding
@@ -71,7 +84,9 @@ jobs:
         run: uv run python -m tbmcp tools --toolsets all
 
       - uses: actions/upload-artifact@v4
-        if: matrix.os == 'windows-latest' && matrix.python == '3.14'
+        # The settled interpreter, not the newest: a wheel regression on 3.14 must
+        # not silently stop the release artifact from being produced.
+        if: matrix.os == 'windows-latest' && matrix.python == '3.13'
         with:
           name: thunderbird-mcp-addon
           path: build/*.xpi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,8 +59,9 @@ jobs:
         # directory must not disable this layer behind a green tick.
         shell: bash
         run: |
-          count=$(ls tests/js/*.test.mjs 2>/dev/null | wc -l)
-          test "$count" -gt 0 || { echo "no add-on test files found"; exit 1; }
+          # `|| true` keeps errexit from ending the step before the message below.
+          count=$(ls tests/js/*.test.mjs 2>/dev/null | wc -l || true)
+          test "$count" -gt 0 || { echo "no add-on test files found under tests/js"; exit 1; }
           node --test "tests/js/*.test.mjs"
 
       - name: Cross-layer consistency

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ build/
 probe/explore.json
 probe/*.log
 *.local.json
+
+# Per-plan review artifacts (subagent-driven development)
+.superpowers/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,103 @@
+# Changelog
+
+## 1.3.0 — 2026-09-08
+
+Every search tool in 1.2.0 was broken, and the bridge could fail in a way nothing
+reported. This release fixes both, adds a test layer that can see the add-on, and
+was verified against Thunderbird 155.
+
+### Fixed
+
+- `mail_search` returned nothing, for every filter. The add-on asked
+  `messages.query` for a list id, which changes the return value to a bare string,
+  and then walked the string.
+- `search_global` and `search_conversation` failed with "An unexpected error
+  occurred". The privileged half called `setTimeout`, which does not exist in its
+  sandbox, so every deadline rejected before the work it guarded began. That also
+  left `search_index_status.indexedMessages` at `null` and quietly removed the
+  deadlines from the calendar, filter and junk tools. Timers now come from the
+  platform's `Timer.sys.mjs`.
+- Every global-search hit carried `date: null`: gloda's `Date` objects come from
+  another realm, so `instanceof Date` was always false. Threads therefore came back
+  unordered. Dates are duck-typed now, and a conversation is oldest-first again.
+- A folder-scoped `search_global` matched nothing. A folder id such as
+  `account1://INBOX` was mistaken for a URI, and the path was sliced one character
+  short. Scoping now compares a hit's own folder id or URI against what the caller
+  passed, and an unknown reference is a usage error that names it.
+- A term the index cannot tokenise (`2.0`) zeroed the whole query. The result now
+  names such terms in `unmatchableTerms` and in the empty-result note; the query
+  itself is unchanged.
+- Errors raised in the privileged half reached the caller as "An unexpected error
+  occurred" with a spurious `[Error]` tag: Thunderbird keeps a message only for an
+  `ExtensionError`. Every method of the privileged API now crosses the boundary in
+  an envelope the background page unpacks, so `mail_save_attachment`'s
+  "already exists, pass overwrite=true" survives the hop as a blocked error.
+- Paging skipped most of a folder. When `limit` stopped mid-page the rest of that
+  page was lost, because continuing a Thunderbird list yields the *next* page:
+  `mail_list(limit=3)` followed by its cursor skipped 97 of 100 messages. The
+  unread remainder is now parked against a cursor of the form `tbx:<load>:<n>`, and
+  a cursor from an earlier Thunderbird session or an evicted page is refused rather
+  than silently resolving elsewhere.
+- Error tags doubled (`[NOT_CONNECTED] [NOT_CONNECTED]`) because the daemon relayed
+  a rendered message and the bridge rendered it again.
+- On `mcp` 2.1 and later every deliberate error message was dropped — the SDK
+  replaces an unrecognised exception with "Error executing tool …". Tools now raise
+  the SDK's `ToolError`, which both 2.0 and 2.2 pass through. Five tests were red on
+  a fresh install before this.
+- A wide answer (about 64 KB, a 200-hit search) dropped the bridge: neither end
+  of the control connection set asyncio's stream limit, so `readline()` raised past
+  the default, and the next call waited out its whole timeout on a dead socket. Both
+  ends now use the protocol's ceiling, an oversized frame is a typed `TOO_LARGE`
+  error, and a stopped read loop retires its connection so the next call reconnects.
+- `mail_search` read `searchedFolders`, `search_global` read `totalMatched` and
+  `search_conversation` read `participants` — none of which the add-on wrote.
+- A daemon that stood down because a newer one had taken over deleted the newer
+  daemon's pairing file and advertisement on its way out.
+- `install-addon` could leave Thunderbird closed: a lost Marionette reply raised
+  before the restart. It now restarts Thunderbird on every exit path and checks a
+  lost reply against the AddonManager before calling it a failure.
+- The manifest asked for a `messages.tags` permission Thunderbird 155 does not
+  recognise (the real ones, `messagesTags` and `messagesTagsList`, were already
+  listed).
+
+### Added
+
+- Handshake telemetry. The daemon records what became of every add-on connection —
+  never upgraded, no hello, bad token, protocol mismatch, welcomed, superseded,
+  disconnected — and `tb_status`, `tb_diagnostics` and `tbmcp doctor` say so.
+  An add-on that keeps connecting without completing the handshake is now reported
+  as exactly that, with the remedy, instead of "ask the user to start Thunderbird".
+- A daemon log file, `<state dir>/tbmcp/daemon.log` (rotating), since the daemon
+  runs detached with its output discarded. `doctor` prints the path.
+- `doctor` compares the installed add-on with the one in the package and tells you
+  to reinstall when they differ, whether or not the bridge is connected; it also
+  shows the add-on's own view of its transport from the startup report.
+- The add-on's transport is defensive now: the hello never waits on a capability
+  probe, a handshake that gets no welcome within 8 s and a connect that never
+  completes within 15 s are closed and retried, a pairing read has a deadline, a
+  daemon that keeps rejecting is backed off rather than hammered, every close is
+  logged with its code, and the state is written to `tbmcp-addon-status.json`.
+- `tb_console` shows the add-on's own `[tbmcp]` lines, which live in the ConsoleAPI
+  storage rather than the error console, merged by time.
+- A node test layer for the add-on (`tests/js`): the real background and
+  privileged scripts run under `node:vm` against fakes of the WebExtension and
+  XPCOM surfaces. 111 tests, run in CI.
+- `tools/smoke_search.py`, a read-only live acceptance run for the search tools.
+- CI covers Python 3.14; Thunderbird 155 is the verified version.
+
+### Changed
+
+- `mail_search` returns `scope` (the folder and account ids the query covered) on a
+  first page instead of a never-populated `searchedFolders`.
+- `search_global` returns `matched`, `retrieved`, `truncated` and, when present,
+  `unmatchableTerms`; `totalAvailable` is only claimed when the whole result set
+  was retrieved.
+- `search_conversation` returns `participants` and `totalAvailable`.
+- Result payloads no longer carry keys with `null` values for fields that were not
+  produced.
+
+Reported in #3.
+
+## 1.2.0 — 2026-08-11
+
+One-command bootstrap. See the GitHub release.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ was verified against Thunderbird 155.
   XPCOM surfaces. 111 tests, run in CI.
 - `tools/smoke_search.py`, a read-only live acceptance run for the search tools.
 - CI covers Python 3.14; Thunderbird 155 is the verified version.
+- `TBMCP_STATE_DIR` overrides where the daemon keeps its advertisement, lock and log
+  on every platform (macOS had no environment variable for it at all).
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,6 +95,8 @@ was verified against Thunderbird 155.
 - `search_conversation` returns `participants` and `totalAvailable`.
 - Result payloads no longer carry keys with `null` values for fields that were not
   produced.
+- `tb_console` records gain `source: "console"` for the add-on's own lines, and
+  `buffered` counts both stores.
 
 Reported in #3.
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Thunderbird from both at the same time.
   series unless you name one occurrence.
 
 > [!NOTE]
-> Everything documented here was verified against a live **Thunderbird 153** on
+> Everything documented here was verified against a live **Thunderbird 155** on
 > Windows 11, not inferred from documentation. The measurements, and the traps found
 > the hard way, are in [docs/VERIFIED-FINDINGS.md](docs/VERIFIED-FINDINGS.md).
 
@@ -88,21 +88,25 @@ Python
 Thunderbird
   executable                 C:\Program Files\Mozilla Thunderbird\thunderbird.exe
   running                    True
-  add-on version (source)    1.2.0
+  add-on version (source)    1.3.0
+  add-on version (installed) 1.3.0
   profile                    C:\Users\VECTOR\AppData\Roaming\Thunderbird\Profiles\81l4u5ba.default-release
-  accounts (from prefs.js)   2
-  outgoing servers           1
+  accounts (from prefs.js)   3
+  outgoing servers           2
   global index db            True
-  add-on startup report      2026-08-11T06:41:40.527Z
+  add-on startup report      2026-09-08T16:22:20.621Z
   privileged modules         12 loaded
   bridge methods             128
 
 Bridge
-  daemon                     pid 31120
+  daemon                     pid 54640
+  daemon log                 C:\Users\VECTOR\AppData\Local\tbmcp\daemon.log
   connected                  True
-  add-on version (live)      1.2.0
+  add-on version (live)      1.3.0
   privileged half            True
-  app                        Thunderbird 153.0.2
+  app                        Thunderbird 155.0
+  add-on handshakes          1 attempt; last welcomed 0 s ago (Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:155.0) Gecko/20100101 Thunderbird/155.0)
+  add-on transport           connected; 0 failed attempts
   tb_status tool call        connected
 
 Tools
@@ -475,8 +479,8 @@ Full detail in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) and
 
 ## Requirements
 
-- Thunderbird 128 or newer — developed and verified against **153**
-- Python 3.11+
+- Thunderbird 128 or newer — developed and verified against **155**
+- Python 3.11 to 3.14
 - Windows, macOS or Linux, including Snap and Flatpak Thunderbird
 
 ---
@@ -492,6 +496,8 @@ active, is itself the diagnosis.
 | Symptom | Cause |
 | --- | --- |
 | "Thunderbird is not connected" | Thunderbird is closed, or the add-on is not installed |
+| the add-on connects but never completes the handshake (`tb_status` and `doctor` say so) | restart Thunderbird; `doctor` shows the daemon's view (`add-on handshakes`) and the add-on's (`add-on transport`), and `<state dir>/tbmcp/daemon.log` has the rest |
+| `doctor` warns the installed add-on is older than the package | `tbmcp install-addon` and restart Thunderbird |
 | "the add-on never wrote its startup report" | the privileged half did not load → `tbmcp install-addon` again |
 | settings tools fail but mail tools work | same cause; check `privileged modules` in `doctor` |
 | full-text search finds nothing | Thunderbird's global indexer is off (Settings → General) |
@@ -503,6 +509,8 @@ active, is itself the diagnosis.
 
 `TBMCP_DEBUG=1` turns on verbose logging to stderr. The add-on logs to Thunderbird's
 error console with a `[tbmcp]` prefix, and `tb_console` returns those lines as a tool.
+`tb_console` also includes the add-on's own `console.*` output, which the error
+console window does not show.
 
 ---
 
@@ -511,12 +519,14 @@ error console with a `[tbmcp]` prefix, and `tb_console` returns those lines as a
 ```bash
 uv venv && uv pip install -e ".[dev]"
 
-pytest                                  # 181 tests, no Thunderbird needed
+pytest                                  # 286 tests, no Thunderbird needed
+node --test "tests/js/*.test.mjs"       # 111 add-on tests under node:vm, no Thunderbird needed
 ruff check . && ruff format --check .
 python tools/check_consistency.py       # do all three layers still agree?
 python tools/build_xpi.py build         # build the add-on package
 python tools/gen_tool_reference.py      # regenerate the tool docs from the code
 python tools/smoke_live.py              # read-only checks against a live Thunderbird
+python tools/smoke_search.py            # the search tools, paging and errors, against a live Thunderbird
 python tools/smoke_write.py             # gated-write checks; leaves the profile unchanged
 ```
 

--- a/README.md
+++ b/README.md
@@ -507,7 +507,8 @@ active, is itself the diagnosis.
 | Claude Code truncates a large result | raise `MAX_MCP_OUTPUT_TOKENS` (default 25,000) |
 | A dependency fails with "DLL load failed" or "cannot open shared object file" | A binary your OS will not load — Windows Application Control blocks unsigned, low-reputation wheels. `bootstrap` detects this and downgrades the offending package automatically; run `python bootstrap.py` and read the `binaries` step. |
 
-`TBMCP_DEBUG=1` turns on verbose logging to stderr. The add-on logs to Thunderbird's
+`TBMCP_DEBUG=1` turns on verbose logging to stderr. `TBMCP_STATE_DIR` moves the
+daemon's advertisement, lock and log out of the platform default. The add-on logs to Thunderbird's
 error console with a `[tbmcp]` prefix, and `tb_console` returns those lines as a tool.
 `tb_console` also includes the add-on's own `console.*` output, which the error
 console window does not show.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/U-C4N/Thunderbird-MCP/actions/workflows/ci.yml/badge.svg)](https://github.com/U-C4N/Thunderbird-MCP/actions/workflows/ci.yml)
 [![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
 [![MCP SDK](https://img.shields.io/badge/MCP%20SDK-2.0-6E56CF)](https://github.com/modelcontextprotocol/python-sdk)
-[![Thunderbird](https://img.shields.io/badge/Thunderbird-128%20%E2%80%93%20153-0A84FF)](https://www.thunderbird.net/)
+[![Thunderbird](https://img.shields.io/badge/Thunderbird-128%20%E2%80%93%20155-0A84FF)](https://www.thunderbird.net/)
 [![Tools](https://img.shields.io/badge/tools-112-brightgreen)](docs/TOOL-REFERENCE.md)
 [![License](https://img.shields.io/badge/license-MIT-green)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/U-C4N/Thunderbird-MCP?style=flat)](https://github.com/U-C4N/Thunderbird-MCP/stargazers)

--- a/addon/background/capabilities.js
+++ b/addon/background/capabilities.js
@@ -56,6 +56,32 @@ var tbxCapabilities = (() => {
   }
 
   return {
+    /**
+     * `promise`, but it always settles, and never with a rejection.
+     *
+     * Anything that crosses into the privileged half can hang — that is the failure
+     * this add-on keeps meeting — and a startup step that hangs takes the bridge
+     * with it, because nothing after it ever runs. Callers get `fallback` instead
+     * and carry on with what they already know.
+     *
+     * @param {Promise} promise
+     * @param {number} ms  how long the caller is prepared to wait.
+     * @param {*} [fallback]  what to resolve with when it does not answer.
+     */
+    bounded(promise, ms, fallback = null) {
+      return new Promise((resolve) => {
+        const timer = setTimeout(() => resolve(fallback), ms);
+        const settle = (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        };
+        promise.then(settle, (ex) => {
+          tbxLog.debug("a privileged call failed:", ex.message || ex);
+          settle(fallback);
+        });
+      });
+    },
+
     async appInfo() {
       if (browser.tbx) {
         try {
@@ -65,8 +91,11 @@ var tbxCapabilities = (() => {
           tbxLog.debug("appInfo failed:", ex.message || ex);
         }
       }
-      lastAppInfo = manifestAppInfo();
-      return lastAppInfo;
+      // The cache is only written by an answer. A probe that failed must not be
+      // able to downgrade what we already know — the transport re-probes after
+      // every welcome, and a wedged privileged half would otherwise turn a good
+      // `hello` into one claiming this is Thunderbird "unknown".
+      return lastAppInfo || manifestAppInfo();
     },
 
     /** The last answer `appInfo()` produced, or the manifest before there was one. */
@@ -79,11 +108,9 @@ var tbxCapabilities = (() => {
         try {
           lastPrivilegedModules = await browser.tbx.availableModules();
         } catch (ex) {
+          // Same as above: keep the last list we were actually given.
           tbxLog.warn("the privileged half loaded but is not answering:", ex.message || ex);
-          lastPrivilegedModules = [];
         }
-      } else {
-        lastPrivilegedModules = [];
       }
       return snapshot(lastPrivilegedModules);
     },

--- a/addon/background/capabilities.js
+++ b/addon/background/capabilities.js
@@ -4,6 +4,11 @@
  * a round trip, and so `tbmcp doctor` can explain a partial install: if the
  * privileged half did not load, every `x.*` method is reported missing up front
  * rather than failing one at a time.
+ *
+ * Both probes cache what they learn, because `hello` cannot wait for them: the
+ * privileged half answers over a message port that a wedged Thunderbird can leave
+ * hanging indefinitely, and a handshake that never starts is far worse than one
+ * carrying a slightly stale description.
  */
 
 var tbxCapabilities = (() => {
@@ -23,44 +28,69 @@ var tbxCapabilities = (() => {
     "windows",
   ];
 
+  let lastAppInfo = null;
+  let lastPrivilegedModules = [];
+
+  /** What we know without asking anyone: the manifest, and our own version. */
+  function manifestAppInfo() {
+    const manifest = browser.runtime.getManifest();
+    return { name: "Thunderbird", version: "unknown", addon: manifest.version };
+  }
+
+  /** Everything except the privileged module list, which needs a round trip. */
+  function snapshot(privilegedModules) {
+    return {
+      experiment: Boolean(browser.tbx),
+      namespaces: WATCHED_NAMESPACES.filter((name) => Boolean(browser[name])),
+      privilegedModules,
+      methods: tbxRegistry.methods(),
+      // Surfaced so the server can adapt instead of guessing from a version number.
+      features: {
+        headlessSend: Boolean(browser.messages && browser.messages.sendMessage),
+        messageImport: Boolean(browser.messages && browser.messages.import),
+        tagsNamespace: Boolean(browser.messages && browser.messages.tags),
+        folderQuery: Boolean(browser.folders && browser.folders.query),
+        unifiedFolders: Boolean(browser.folders && browser.folders.getUnifiedFolder),
+      },
+    };
+  }
+
   return {
     async appInfo() {
       if (browser.tbx) {
         try {
-          return await browser.tbx.appInfo();
+          lastAppInfo = await browser.tbx.appInfo();
+          return lastAppInfo;
         } catch (ex) {
           tbxLog.debug("appInfo failed:", ex.message || ex);
         }
       }
-      const manifest = browser.runtime.getManifest();
-      return { name: "Thunderbird", version: "unknown", addon: manifest.version };
+      lastAppInfo = manifestAppInfo();
+      return lastAppInfo;
+    },
+
+    /** The last answer `appInfo()` produced, or the manifest before there was one. */
+    appInfoSync() {
+      return lastAppInfo || manifestAppInfo();
     },
 
     async describe() {
-      const namespaces = WATCHED_NAMESPACES.filter((name) => Boolean(browser[name]));
-      const privileged = Boolean(browser.tbx);
-      let privilegedModules = [];
-      if (privileged) {
+      if (browser.tbx) {
         try {
-          privilegedModules = await browser.tbx.availableModules();
+          lastPrivilegedModules = await browser.tbx.availableModules();
         } catch (ex) {
           tbxLog.warn("the privileged half loaded but is not answering:", ex.message || ex);
+          lastPrivilegedModules = [];
         }
+      } else {
+        lastPrivilegedModules = [];
       }
-      return {
-        experiment: privileged,
-        namespaces,
-        privilegedModules,
-        methods: tbxRegistry.methods(),
-        // Surfaced so the server can adapt instead of guessing from a version number.
-        features: {
-          headlessSend: Boolean(browser.messages && browser.messages.sendMessage),
-          messageImport: Boolean(browser.messages && browser.messages.import),
-          tagsNamespace: Boolean(browser.messages && browser.messages.tags),
-          folderQuery: Boolean(browser.folders && browser.folders.query),
-          unifiedFolders: Boolean(browser.folders && browser.folders.getUnifiedFolder),
-        },
-      };
+      return snapshot(lastPrivilegedModules);
+    },
+
+    /** `describe()` minus the round trip: the module list is whatever it last saw. */
+    describeSync() {
+      return snapshot(lastPrivilegedModules);
     },
   };
 })();

--- a/addon/background/capabilities.js
+++ b/addon/background/capabilities.js
@@ -88,7 +88,7 @@ var tbxCapabilities = (() => {
           lastAppInfo = await browser.tbx.appInfo();
           return lastAppInfo;
         } catch (ex) {
-          tbxLog.debug("appInfo failed:", ex.message || ex);
+          tbxLog.debug("appInfo failed:", tbxError.readable(ex));
         }
       }
       // The cache is only written by an answer. A probe that failed must not be
@@ -109,7 +109,10 @@ var tbxCapabilities = (() => {
           lastPrivilegedModules = await browser.tbx.availableModules();
         } catch (ex) {
           // Same as above: keep the last list we were actually given.
-          tbxLog.warn("the privileged half loaded but is not answering:", ex.message || ex);
+          tbxLog.warn(
+            "the privileged half loaded but is not answering:",
+            tbxError.readable(ex)
+          );
         }
       }
       return snapshot(lastPrivilegedModules);

--- a/addon/background/handlers/compose.js
+++ b/addon/background/handlers/compose.js
@@ -123,7 +123,9 @@
     try {
       read = await browser.tbx.invoke("files.read", { path });
     } catch (ex) {
-      throw tbxError.usage(`could not read attachment ${path}: ${ex.message || ex}`);
+      // The privileged half packs its failures into the message; say what it said.
+      const failure = tbxError.fromWire(ex) || ex;
+      throw tbxError.usage(`could not read attachment ${path}: ${failure.message || failure}`);
     }
     return fileFromBase64(name || read.name, read.base64, read.contentType);
   }

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -83,14 +83,28 @@
 
   // --------------------------------------------------------------------- query
 
+  /**
+   * Run a query and return its first page.
+   *
+   * Never ask for `returnMessageListId`: that flag makes Thunderbird answer with
+   * the list id itself, a bare string with no messages on it, which is how every
+   * search used to come back empty. A build that answers with one anyway is one
+   * `continueList` away from the page we wanted.
+   */
+  async function startQuery(query) {
+    const first = await browser.messages.query(query);
+    return typeof first === "string" ? browser.messages.continueList(first) : first;
+  }
+
   tbxRegistry.define("messages.query", async (params) => {
     const limit = params.limit || DEFAULT_LIMIT;
     const query = Object.assign({}, params.query || {});
-    // Ask Thunderbird for a resumable list rather than one giant array.
-    query.returnMessageListId = true;
-    query.messagesPerPage = Math.min(Math.max(limit, 10), 100);
+    // Any positive page size is legal; asking for exactly what the caller wants
+    // keeps the common case to one round trip. Thunderbird may still cut a page
+    // short (autoPaginationTimeout), so the walk below loops regardless.
+    query.messagesPerPage = limit;
 
-    const list = await resumeOrStart(params.cursor, () => browser.messages.query(query));
+    const list = await resumeOrStart(params.cursor, () => startQuery(query));
     const paged = await takePage(list, limit);
     const result = { messages: paged.messages, cursor: paged.cursor };
     if (query.fullText && browser.tbx) {

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -96,6 +96,32 @@
     return typeof first === "string" ? browser.messages.continueList(first) : first;
   }
 
+  /** A folder or account id, or a list of them, as a list — or null for neither. */
+  function idList(value) {
+    if (!value) {
+      return null;
+    }
+    return Array.isArray(value) ? [...value] : [value];
+  }
+
+  /**
+   * What the search was aimed at, echoed back so the answer says what it covered
+   * without anyone having to enumerate folders to find out.
+   */
+  function queryScope(query) {
+    const folderIds = idList(query.folderId);
+    const accountIds = idList(query.accountId);
+    return {
+      folderIds,
+      accountIds,
+      // There is nothing to recurse into unless a folder or account was named.
+      includeSubFolders:
+        typeof query.includeSubFolders === "boolean"
+          ? query.includeSubFolders
+          : Boolean(folderIds || accountIds),
+    };
+  }
+
   tbxRegistry.define("messages.query", async (params) => {
     const limit = params.limit || DEFAULT_LIMIT;
     const query = Object.assign({}, params.query || {});
@@ -107,6 +133,10 @@
     const list = await resumeOrStart(params.cursor, () => startQuery(query));
     const paged = await takePage(list, limit);
     const result = { messages: paged.messages, cursor: paged.cursor };
+    if (!params.cursor) {
+      // Only on the first page: a continuation is by definition the same search.
+      result.scope = queryScope(query);
+    }
     if (query.fullText && browser.tbx) {
       // Worth saying: fullText only sees what the global indexer has processed.
       const indexed = await browser.tbx.globalIndexEnabled().catch(() => null);

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -14,8 +14,10 @@
  * between the two. So a cursor is one of:
  *   - a raw Thunderbird list id, when the page ended exactly on the limit and
  *     nothing was left over;
- *   - `tbx:<n>`, ours, naming the tail we parked (with the id that continues
- *     after it) because the limit stopped us mid-page.
+ *   - `tbx:<load>:<n>`, ours, naming the tail we parked (with the id that
+ *     continues after it) because the limit stopped us mid-page. `<load>` names
+ *     this load of the script, so a cursor from before a background restart is
+ *     refused rather than mistaken for one of ours.
  * Only the last 32 part-read pages are kept; the rest are dropped, and their
  * Thunderbird lists aborted, so an abandoned walk costs nothing.
  */
@@ -60,6 +62,12 @@
   const parked = new Map();
   let parkSequence = 0;
 
+  /* Every cursor we mint names this load of the script. The map above is empty
+   * again after a background restart, and without this a cursor from before it
+   * would quietly claim the new load's first parked page instead of being
+   * refused. */
+  const LOAD_ID = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+
   /** Let go of a Thunderbird list nobody can reach any more. */
   function abandonList(listId) {
     if (listId) {
@@ -76,12 +84,18 @@
       parked.delete(oldest);
     }
     parkSequence += 1;
-    const cursor = `${CURSOR_PREFIX}${parkSequence}`;
+    const cursor = `${CURSOR_PREFIX}${LOAD_ID}:${parkSequence}`;
     parked.set(cursor, { listId, rest });
     return cursor;
   }
 
-  /** Take back a page we parked, or say why the cursor is worthless. */
+  /**
+   * Take back a page we parked, or say why the cursor is worthless.
+   *
+   * Anything carrying our prefix is ours to answer for: a cursor from another
+   * load carries another load id, so it is simply not in the map, and it is
+   * refused here rather than handed to Thunderbird as if it were a list id.
+   */
   function unpark(cursor) {
     const held = parked.get(cursor);
     if (!held) {

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -112,7 +112,7 @@
   /**
    * Collect up to `limit` headers, starting a walk or resuming one.
    *
-   * @param {string|null} cursor  ours (`tbx:<n>`) or a raw Thunderbird list id.
+   * @param {string|null} cursor  ours (`tbx:<load>:<n>`) or a raw Thunderbird list id.
    * @param {Function} start  opens the list, when there is no cursor to resume.
    */
   async function collectPage(cursor, start, limit) {

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -7,14 +7,24 @@
  *   - use `tbxUtil.mapLimited` for bulk work so a 500-message operation neither
  *     stalls the UI nor opens 500 IMAP requests at once
  *
- * Pagination note: Thunderbird returns a `MessageList` with an opaque `id` plus a
- * first page, and `messages.continueList(id)` walks it. We surface that id as our
- * `cursor` unchanged.
+ * Pagination note: Thunderbird hands out a `MessageList` — one page of messages
+ * plus an `id` that continues *after* that page. Page size is the user's own
+ * preference (`extensions.webextensions.messagesPerPage`), so a `limit` usually
+ * runs out mid-page, and returning the list id there would skip everything
+ * between the two. So a cursor is one of:
+ *   - a raw Thunderbird list id, when the page ended exactly on the limit and
+ *     nothing was left over;
+ *   - `tbx:<n>`, ours, naming the tail we parked (with the id that continues
+ *     after it) because the limit stopped us mid-page.
+ * Only the last 32 part-read pages are kept; the rest are dropped, and their
+ * Thunderbird lists aborted, so an abandoned walk costs nothing.
  */
 
 {
   const DEFAULT_LIMIT = 25;
   const BULK_CONCURRENCY = 8;
+  const PARKED_PAGES = 32;
+  const CURSOR_PREFIX = "tbx:";
 
   /** Flatten a MessageHeader into the shape _common.message_summary expects. */
   function header(message) {
@@ -44,33 +54,72 @@
     };
   }
 
-  /** Walk a MessageList to at most `limit` items, returning a continuation cursor. */
-  async function takePage(list, limit) {
-    const messages = [];
-    let current = list;
-    while (current) {
-      for (const message of current.messages || []) {
-        messages.push(header(message));
-        if (messages.length >= limit) {
-          // Keep the list alive so the caller can continue from it.
-          return { messages, cursor: current.id || null };
-        }
-      }
-      if (!current.id) {
-        return { messages, cursor: null };
-      }
-      current = await browser.messages.continueList(current.id);
-      if (!current || !current.messages || current.messages.length === 0) {
-        return { messages, cursor: current && current.id ? current.id : null };
-      }
+  /* Pages we stopped part-way through, by the cursor we minted for them. Bounded,
+   * because a caller that walks away from a search must not pin its messages —
+   * and its Thunderbird list — for the rest of the session. */
+  const parked = new Map();
+  let parkSequence = 0;
+
+  /** Let go of a Thunderbird list nobody can reach any more. */
+  function abandonList(listId) {
+    if (listId) {
+      // Best effort: the list would expire on its own, this is just sooner.
+      Promise.resolve(browser.messages.abortList(listId)).catch(() => {});
     }
-    return { messages, cursor: null };
   }
 
-  async function resumeOrStart(cursor, start) {
-    if (cursor) {
+  /** Hold `rest` for the next call, and return the cursor that claims it back. */
+  function park(listId, rest) {
+    if (parked.size >= PARKED_PAGES) {
+      const [oldest] = parked.keys(); // a Map iterates in insertion order
+      abandonList(parked.get(oldest).listId);
+      parked.delete(oldest);
+    }
+    parkSequence += 1;
+    const cursor = `${CURSOR_PREFIX}${parkSequence}`;
+    parked.set(cursor, { listId, rest });
+    return cursor;
+  }
+
+  /** Take back a page we parked, or say why the cursor is worthless. */
+  function unpark(cursor) {
+    const held = parked.get(cursor);
+    if (!held) {
+      throw tbxError.usage(
+        `that cursor is no longer valid: it was evicted (only ${PARKED_PAGES} part-read ` +
+          "pages are kept) or belongs to an earlier Thunderbird session — re-run the " +
+          "search without a cursor"
+      );
+    }
+    parked.delete(cursor);
+    return held;
+  }
+
+  /**
+   * Collect up to `limit` headers, starting a walk or resuming one.
+   *
+   * @param {string|null} cursor  ours (`tbx:<n>`) or a raw Thunderbird list id.
+   * @param {Function} start  opens the list, when there is no cursor to resume.
+   */
+  async function collectPage(cursor, start, limit) {
+    const messages = [];
+    let pending = []; // fetched but not yet returned, in order
+    let listId = null; // the Thunderbird list that continues after `pending`
+
+    const absorb = (page) => {
+      pending = page && page.messages ? [...page.messages] : [];
+      listId = (page && page.id) || null;
+    };
+
+    if (!cursor) {
+      absorb(await start());
+    } else if (cursor.startsWith(CURSOR_PREFIX)) {
+      const held = unpark(cursor);
+      pending = held.rest;
+      listId = held.listId;
+    } else {
       try {
-        return await browser.messages.continueList(cursor);
+        absorb(await browser.messages.continueList(cursor));
       } catch (ex) {
         throw tbxError.usage(
           "that cursor has expired (Thunderbird drops message lists when it restarts " +
@@ -78,7 +127,27 @@
         );
       }
     }
-    return start();
+
+    for (;;) {
+      while (pending.length) {
+        if (messages.length >= limit) {
+          // Stopped mid-page: park the rest, because the list id continues after
+          // the whole page and would skip every message still sitting here.
+          return { messages, cursor: park(listId, pending) };
+        }
+        messages.push(header(pending.shift()));
+      }
+      if (messages.length >= limit || !listId) {
+        // Nothing left over, so Thunderbird's own id is the cursor; when the list
+        // is spent there is no id and the walk is over.
+        return { messages, cursor: listId };
+      }
+      absorb(await browser.messages.continueList(listId));
+      if (!pending.length) {
+        // An empty page ends this call; its id, if any, can still be resumed.
+        return { messages, cursor: listId };
+      }
+    }
   }
 
   // --------------------------------------------------------------------- query
@@ -130,8 +199,7 @@
     // short (autoPaginationTimeout), so the walk below loops regardless.
     query.messagesPerPage = limit;
 
-    const list = await resumeOrStart(params.cursor, () => startQuery(query));
-    const paged = await takePage(list, limit);
+    const paged = await collectPage(params.cursor, () => startQuery(query), limit);
     const result = { messages: paged.messages, cursor: paged.cursor };
     if (!params.cursor) {
       // Only on the first page: a continuation is by definition the same search.
@@ -152,13 +220,15 @@
   tbxRegistry.define("messages.list", async (params) => {
     const folderId = tbxUtil.need(params, "folderId", "string");
     const limit = params.limit || DEFAULT_LIMIT;
-    const list = await resumeOrStart(params.cursor, () =>
-      browser.messages.list(folderId, {
-        sortType: params.sortType || "date",
-        sortOrder: params.sortOrder || "descending",
-      })
+    const paged = await collectPage(
+      params.cursor,
+      () =>
+        browser.messages.list(folderId, {
+          sortType: params.sortType || "date",
+          sortOrder: params.sortOrder || "descending",
+        }),
+      limit
     );
-    const paged = await takePage(list, limit);
     return { messages: paged.messages, cursor: paged.cursor, folderId };
   });
 

--- a/addon/background/handlers/messages.js
+++ b/addon/background/handlers/messages.js
@@ -386,12 +386,19 @@
         "saving files needs the privileged half of the add-on, which did not load"
       );
     }
-    const written = await browser.tbx.writeFile({
-      directory,
-      filename: params.filename || file.name,
-      base64: tbxBase64.fromArrayBuffer(buffer),
-      overwrite: Boolean(params.overwrite),
-    });
+    let written;
+    try {
+      written = await browser.tbx.writeFile({
+        directory,
+        filename: params.filename || file.name,
+        base64: tbxBase64.fromArrayBuffer(buffer),
+        overwrite: Boolean(params.overwrite),
+      });
+    } catch (ex) {
+      // "already exists — pass overwrite=true" is exactly the kind of refusal the
+      // caller can act on, and it only survives the hop packed into a message.
+      throw tbxError.fromWire(ex) || ex;
+    }
     return { path: written.path, bytes: written.bytes, name: written.name };
   });
 

--- a/addon/background/handlers/privileged.js
+++ b/addon/background/handlers/privileged.js
@@ -28,6 +28,53 @@
     return known;
   }
 
+  /** The tag experiment/core.js packs a failure's whole taxonomy into. */
+  const ERROR_TAG = "tbxerr:";
+
+  /**
+   * Re-raise what the privileged half threw, in the kind it chose.
+   *
+   * Only a message crosses that boundary — `normalizeError` drops everything
+   * else about an error raised with the system principal — so the experiment
+   * serialises kind, code and needs into the message and this unpacks them. An
+   * untagged message is Thunderbird's own failure, or an add-on half older than
+   * this one, and still gets the guesswork it always got.
+   */
+  function retag(ex) {
+    const message = String(ex.message || ex);
+    if (message.startsWith(ERROR_TAG)) {
+      let payload = null;
+      try {
+        payload = JSON.parse(message.slice(ERROR_TAG.length));
+      } catch (parseError) {
+        payload = null; // not ours after all; fall through to the heuristics
+      }
+      if (payload && payload.message) {
+        const extra = payload.code ? { code: payload.code } : undefined;
+        switch (payload.kind) {
+          case "usage":
+            return tbxError.usage(payload.message, extra);
+          case "unsupported":
+            return tbxError.unsupported(payload.message, extra);
+          case "blocked":
+            return tbxError.blocked(payload.message, payload.needs, extra);
+          default:
+            return tbxError.thunderbird(payload.message, extra);
+        }
+      }
+    }
+    if (/ is required|must be|unknown privileged method|not an? /.test(message)) {
+      return tbxError.usage(message);
+    }
+    if (/does not expose|unavailable/.test(message)) {
+      return tbxError.unsupported(message);
+    }
+    if (/not writable|will not be written|locked by/.test(message)) {
+      return tbxError.blocked(message);
+    }
+    return tbxError.thunderbird(message);
+  }
+
   /**
    * A single catch-all handler. `tbxRegistry.invoke` only reaches us for methods
    * that were registered, so we register the prefix itself and let the transport's
@@ -56,19 +103,7 @@
     try {
       return await browser.tbx.invoke(bare, params);
     } catch (ex) {
-      // Errors thrown inside the experiment arrive as plain Error objects with the
-      // message intact; re-tag them so the taxonomy survives the hop.
-      const message = String(ex.message || ex);
-      if (/ is required|must be|unknown privileged method|not an? /.test(message)) {
-        throw tbxError.usage(message);
-      }
-      if (/does not expose|unavailable/.test(message)) {
-        throw tbxError.unsupported(message);
-      }
-      if (/not writable|will not be written|locked by/.test(message)) {
-        throw tbxError.blocked(message);
-      }
-      throw tbxError.thunderbird(message);
+      throw retag(ex);
     }
   };
 

--- a/addon/background/handlers/privileged.js
+++ b/addon/background/handlers/privileged.js
@@ -22,7 +22,7 @@
       const report = await browser.tbx.availableModules();
       known = report.methods || [];
     } catch (ex) {
-      tbxLog.warn("could not enumerate privileged methods:", ex.message || ex);
+      tbxLog.warn("could not enumerate privileged methods:", tbxError.readable(ex));
       known = [];
     }
     return known;

--- a/addon/background/handlers/privileged.js
+++ b/addon/background/handlers/privileged.js
@@ -28,41 +28,18 @@
     return known;
   }
 
-  /** The tag experiment/core.js packs a failure's whole taxonomy into. */
-  const ERROR_TAG = "tbxerr:";
-
   /**
    * Re-raise what the privileged half threw, in the kind it chose.
    *
-   * Only a message crosses that boundary — `normalizeError` drops everything
-   * else about an error raised with the system principal — so the experiment
-   * serialises kind, code and needs into the message and this unpacks them. An
-   * untagged message is Thunderbird's own failure, or an add-on half older than
-   * this one, and still gets the guesswork it always got.
+   * An untagged message is Thunderbird's own failure, or an add-on half older
+   * than this one, and still gets the guesswork it always got.
    */
   function retag(ex) {
-    const message = String(ex.message || ex);
-    if (message.startsWith(ERROR_TAG)) {
-      let payload = null;
-      try {
-        payload = JSON.parse(message.slice(ERROR_TAG.length));
-      } catch (parseError) {
-        payload = null; // not ours after all; fall through to the heuristics
-      }
-      if (payload && payload.message) {
-        const extra = payload.code ? { code: payload.code } : undefined;
-        switch (payload.kind) {
-          case "usage":
-            return tbxError.usage(payload.message, extra);
-          case "unsupported":
-            return tbxError.unsupported(payload.message, extra);
-          case "blocked":
-            return tbxError.blocked(payload.message, payload.needs, extra);
-          default:
-            return tbxError.thunderbird(payload.message, extra);
-        }
-      }
+    const typed = tbxError.fromWire(ex);
+    if (typed) {
+      return typed;
     }
+    const message = String(ex.message || ex);
     if (/ is required|must be|unknown privileged method|not an? /.test(message)) {
       return tbxError.usage(message);
     }

--- a/addon/background/main.js
+++ b/addon/background/main.js
@@ -122,7 +122,7 @@
       browser.tbx
         .writeStatus({ ...report, transport, writtenAt: new Date().toISOString() })
         .catch((ex) => {
-          tbxLog.warn("could not update the status file:", ex.message || ex);
+          tbxLog.warn("could not update the status file:", tbxError.readable(ex));
         });
     },
   });

--- a/addon/background/main.js
+++ b/addon/background/main.js
@@ -21,6 +21,11 @@
   // itself is broken there is no channel left to report through, so `tbmcp doctor`
   // reads this file instead — and its absence on an installed, active add-on is
   // itself the diagnosis: the privileged half never loaded.
+  // What the transport announces in its `hello`. Fetched here because the status
+  // file needs the same two values, and because the handshake must never wait on a
+  // probe: whatever we learn now is what the first hello carries.
+  let identity = { app: null, capabilities: null };
+
   if (browser.tbx) {
     // First, and most important: stop Thunderbird suspending this page. It ships
     // extensions.eventPages.enabled=true, which makes MV2's "persistent": true a
@@ -58,12 +63,15 @@
     }
 
     try {
-      const capabilities = await tbxCapabilities.describe();
+      identity = {
+        capabilities: await tbxCapabilities.describe(),
+        app: await tbxCapabilities.appInfo(),
+      };
       await browser.tbx.writeStatus({
         writtenAt: new Date().toISOString(),
         addonVersion: manifest.version,
-        app: await tbxCapabilities.appInfo(),
-        capabilities,
+        app: identity.app,
+        capabilities: identity.capabilities,
         methodCount: tbxRegistry.methods().length,
       });
     } catch (ex) {
@@ -72,7 +80,7 @@
   }
 
   tbxEvents.start();
-  tbxTransport.start();
+  tbxTransport.start(identity);
 
   browser.runtime.onSuspend.addListener(() => {
     tbxLog.info("suspending — closing the bridge");

--- a/addon/background/main.js
+++ b/addon/background/main.js
@@ -57,7 +57,7 @@
       tbxLog.error(
         "could not stop the background page being suspended, so the bridge will drop " +
           "out after about 30s of inactivity:",
-        ex.message || ex
+        tbxError.readable(ex)
       );
     }
 
@@ -78,7 +78,7 @@
     } catch (ex) {
       tbxLog.warn(
         "could not grant messages.send, so sending will open a compose window:",
-        ex.message || ex
+        tbxError.readable(ex)
       );
     }
 
@@ -105,7 +105,7 @@
         throw new Error(`no answer within ${PROBE_TIMEOUT_MS}ms`);
       }
     } catch (ex) {
-      tbxLog.warn("could not write the status file:", ex.message || ex);
+      tbxLog.warn("could not write the status file:", tbxError.readable(ex));
     }
   }
 

--- a/addon/background/main.js
+++ b/addon/background/main.js
@@ -1,6 +1,11 @@
 /* Entry point. Loaded last, after every handler module has registered itself. */
 
 (async () => {
+  /* Nothing on the way to `tbxTransport.start()` may be able to hang. Every call
+   * below crosses into the privileged half, which is the part that wedges, and a
+   * bridge that never starts cannot even report that it did not. */
+  const PROBE_TIMEOUT_MS = 5000;
+
   await tbxLog.init();
   const manifest = browser.runtime.getManifest();
   tbxLog.info(
@@ -36,7 +41,13 @@
     // timers and the bridge socket with it, and the connection only returns when some
     // unrelated mail event happens to wake us.
     try {
-      const alive = await browser.tbx.keepAlive(true);
+      const alive = await tbxCapabilities.bounded(
+        browser.tbx.keepAlive(true),
+        PROBE_TIMEOUT_MS
+      );
+      if (!alive) {
+        throw new Error(`no answer within ${PROBE_TIMEOUT_MS}ms`);
+      }
       tbxLog.info(
         alive.enabled
           ? `keep-alive on (every ${alive.intervalMs}ms; idle timeout ${alive.idleTimeoutMs}ms)`
@@ -54,7 +65,13 @@
     // window. It is an OptionalOnlyPermission, so it cannot be asked for in the
     // manifest and needs a click we do not have. See grantOptionalPermission.
     try {
-      const grant = await browser.tbx.grantOptionalPermission("messages.send");
+      const grant = await tbxCapabilities.bounded(
+        browser.tbx.grantOptionalPermission("messages.send"),
+        PROBE_TIMEOUT_MS
+      );
+      if (!grant) {
+        throw new Error(`no answer within ${PROBE_TIMEOUT_MS}ms`);
+      }
       if (!grant.alreadyHad) {
         tbxLog.info(`granted messages.send: ${grant.granted}`);
       }
@@ -66,18 +83,27 @@
     }
 
     try {
-      identity = {
-        capabilities: await tbxCapabilities.describe(),
-        app: await tbxCapabilities.appInfo(),
-      };
+      // Whatever these two do not answer in time stays null, and `hello` falls back
+      // to the capability snapshots instead.
+      const [capabilities, app] = await Promise.all([
+        tbxCapabilities.bounded(tbxCapabilities.describe(), PROBE_TIMEOUT_MS),
+        tbxCapabilities.bounded(tbxCapabilities.appInfo(), PROBE_TIMEOUT_MS),
+      ]);
+      identity = { app, capabilities };
       report = {
         writtenAt: new Date().toISOString(),
         addonVersion: manifest.version,
-        app: identity.app,
-        capabilities: identity.capabilities,
+        app,
+        capabilities,
         methodCount: tbxRegistry.methods().length,
       };
-      await browser.tbx.writeStatus(report);
+      const written = await tbxCapabilities.bounded(
+        browser.tbx.writeStatus(report),
+        PROBE_TIMEOUT_MS
+      );
+      if (!written) {
+        throw new Error(`no answer within ${PROBE_TIMEOUT_MS}ms`);
+      }
     } catch (ex) {
       tbxLog.warn("could not write the status file:", ex.message || ex);
     }

--- a/addon/background/main.js
+++ b/addon/background/main.js
@@ -17,15 +17,18 @@
     );
   }
 
-  // Leave a record on disk before doing anything that could fail. When the bridge
-  // itself is broken there is no channel left to report through, so `tbmcp doctor`
-  // reads this file instead — and its absence on an installed, active add-on is
-  // itself the diagnosis: the privileged half never loaded.
   // What the transport announces in its `hello`. Fetched here because the status
   // file needs the same two values, and because the handshake must never wait on a
   // probe: whatever we learn now is what the first hello carries.
   let identity = { app: null, capabilities: null };
+  // The startup report, kept so the transport's state can be added to it later
+  // without probing anything again.
+  let report = null;
 
+  // Leave a record on disk before doing anything that could fail. When the bridge
+  // itself is broken there is no channel left to report through, so `tbmcp doctor`
+  // reads this file instead — and its absence on an installed, active add-on is
+  // itself the diagnosis: the privileged half never loaded.
   if (browser.tbx) {
     // First, and most important: stop Thunderbird suspending this page. It ships
     // extensions.eventPages.enabled=true, which makes MV2's "persistent": true a
@@ -67,20 +70,36 @@
         capabilities: await tbxCapabilities.describe(),
         app: await tbxCapabilities.appInfo(),
       };
-      await browser.tbx.writeStatus({
+      report = {
         writtenAt: new Date().toISOString(),
         addonVersion: manifest.version,
         app: identity.app,
         capabilities: identity.capabilities,
         methodCount: tbxRegistry.methods().length,
-      });
+      };
+      await browser.tbx.writeStatus(report);
     } catch (ex) {
       tbxLog.warn("could not write the status file:", ex.message || ex);
     }
   }
 
   tbxEvents.start();
-  tbxTransport.start(identity);
+  tbxTransport.start(identity, {
+    /* A connection that never works leaves nothing else to look at: the daemon
+     * cannot report what it never heard from, and the console is gone by the time
+     * anyone runs `tbmcp doctor`. So the same file the startup report goes into
+     * gains the transport's own account of what has been happening. */
+    onStateChange(transport) {
+      if (!report) {
+        return;
+      }
+      browser.tbx
+        .writeStatus({ ...report, transport, writtenAt: new Date().toISOString() })
+        .catch((ex) => {
+          tbxLog.warn("could not update the status file:", ex.message || ex);
+        });
+    },
+  });
 
   browser.runtime.onSuspend.addListener(() => {
     tbxLog.info("suspending — closing the bridge");

--- a/addon/background/registry.js
+++ b/addon/background/registry.js
@@ -22,6 +22,39 @@ var tbxError = {
   thunderbird(message, extra) {
     return Object.assign(new Error(message), { tbxKind: "thunderbird", ...extra });
   },
+  /**
+   * Unpack a failure the privileged half packed into a message, or null.
+   *
+   * Only a message survives the hop out of the experiment sandbox, so
+   * experiment/core.js serialises the whole taxonomy into one and everything
+   * that calls `browser.tbx.invoke` unpacks it here.
+   */
+  fromWire(ex) {
+    const message = String((ex && ex.message) || ex);
+    if (!message.startsWith("tbxerr:")) {
+      return null;
+    }
+    let payload = null;
+    try {
+      payload = JSON.parse(message.slice("tbxerr:".length));
+    } catch (parseError) {
+      return null; // a message that merely starts like ours
+    }
+    if (!payload || !payload.message) {
+      return null;
+    }
+    const extra = payload.code ? { code: payload.code } : undefined;
+    switch (payload.kind) {
+      case "usage":
+        return this.usage(payload.message, extra);
+      case "unsupported":
+        return this.unsupported(payload.message, extra);
+      case "blocked":
+        return this.blocked(payload.message, payload.needs, extra);
+      default:
+        return this.thunderbird(payload.message, extra);
+    }
+  },
   /** Normalise anything thrown into the wire shape. */
   serialize(ex) {
     if (!ex) {

--- a/addon/background/registry.js
+++ b/addon/background/registry.js
@@ -30,7 +30,9 @@ var tbxError = {
     const payload = {
       kind: ex.tbxKind || "thunderbird",
       message: String(ex.message || ex),
-      code: ex.code || ex.name || null,
+      // A bare "Error" is not a code — it reached the model as a second, empty
+      // failure tag alongside the real one.
+      code: ex.code || (ex.name && ex.name !== "Error" ? ex.name : null),
     };
     if (ex.needs) {
       payload.needs = Array.isArray(ex.needs) ? ex.needs : [ex.needs];

--- a/addon/background/registry.js
+++ b/addon/background/registry.js
@@ -55,6 +55,12 @@ var tbxError = {
         return this.thunderbird(payload.message, extra);
     }
   },
+  /** What to print about a failure: our envelope unwrapped, or the message as-is.
+   *  For a log line, where the kind and the needs have nowhere to go. */
+  readable(ex) {
+    const typed = this.fromWire(ex);
+    return String((typed && typed.message) || (ex && ex.message) || ex);
+  },
   /** Normalise anything thrown into the wire shape. */
   serialize(ex) {
     if (!ex) {

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -60,7 +60,7 @@ var tbxTransport = (() => {
   let welcomed = false; // has the live socket completed its handshake?
   let connecting = false; // a connect() is between reading the pairing and its socket
   let lastPairing = null; // {port, token} of the daemon the schedules apply to
-  let consecutiveFailures = 0; // closes since the last `welcome`
+  let consecutiveFailures = 0; // attempts in a row that ended without a `welcome`
   let lastCloseCode = null;
   let lastCloseAt = null;
   let lastWelcomeAt = null;
@@ -278,7 +278,12 @@ var tbxTransport = (() => {
     }
     tbxLog.debug(`retrying in ${delay}ms (${why})`);
     clearTimeout(retryTimer);
-    retryTimer = setTimeout(connect, delay);
+    retryTimer = setTimeout(() => {
+      // Cleared before the attempt, not after it: `retryTimer` is what tells the
+      // supervisor whether the chain still has a link left to follow.
+      retryTimer = null;
+      connect();
+    }, delay);
   }
 
   /**
@@ -407,14 +412,19 @@ var tbxTransport = (() => {
       // thing a user needs to be able to see without turning on verbose logging.
       tbxLog.info(`socket closed (code ${code}: ${reason})`);
 
-      consecutiveFailures += 1;
-      if (consecutiveFailures === HANDSHAKE_ALARM_AFTER) {
-        // Once per run of failures. Saying it every time would bury it.
-        tbxLog.error(
-          `the daemon on port ${pairing.port} accepted ${consecutiveFailures} connections ` +
-            "but none completed the handshake — restart Thunderbird if this persists; " +
-            "`tbmcp doctor` shows the daemon's view"
-        );
+      // Only an attempt that never reached `welcome` counts: a daemon that worked
+      // and then went away is not this end failing, and counting it would make the
+      // complaint below claim a handshake failed when one had just succeeded.
+      if (!hadWelcome) {
+        consecutiveFailures += 1;
+        if (consecutiveFailures === HANDSHAKE_ALARM_AFTER) {
+          // Once per run of failures. Saying it every time would bury it.
+          tbxLog.error(
+            `the daemon on port ${pairing.port} accepted ${consecutiveFailures} connections ` +
+              "but none completed the handshake — restart Thunderbird if this persists; " +
+              "`tbmcp doctor` shows the daemon's view"
+          );
+        }
       }
       notify(false);
 
@@ -466,17 +476,21 @@ var tbxTransport = (() => {
    *    one stays open, so nothing tells us to move, and every tool call through the
    *    new daemon reports "Thunderbird is not connected" while both sides look fine.
    *    Comparing the advertised port to ours catches that.
-   * 2. `connect()` returns early whenever a socket already exists, so if it is ever
-   *    entered while one is still CONNECTING, no new timer gets armed and the chain
-   *    dies until that socket closes. A periodic tick makes that unrecoverable state
-   *    impossible.
+   * 2. The retry chain ends up with no link left to follow. The watchdogs above make
+   *    that all but impossible now — a socket that stalls at either half of the
+   *    handshake closes itself, and a close always arms a retry — so this is a
+   *    safety net, and it must behave like one: a retry that is already armed owns
+   *    the schedule, and taking it over turned every backoff longer than the tick
+   *    into a ten-second one.
    */
   async function supervise() {
     if (stopped) {
       return;
     }
     if (!socket) {
-      connect();
+      if (!retryTimer) {
+        connect();
+      }
       return;
     }
     if (socket.readyState !== WebSocket.OPEN) {
@@ -519,6 +533,7 @@ var tbxTransport = (() => {
     stop() {
       stopped = true;
       clearTimeout(retryTimer);
+      retryTimer = null;
       clearTimeout(helloTimer);
       clearTimeout(connectTimer);
       clearInterval(supervisor);

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -36,6 +36,12 @@ var tbxTransport = (() => {
    * concerned — no error event, no close — so nothing else would ever free it. */
   const CONNECT_TIMEOUT_MS = 15000;
 
+  /** Connections in a row that reached the daemon and got no `welcome`. */
+  const HANDSHAKE_ALARM_AFTER = 3;
+
+  /** Floor on how often the state is pushed out to whoever asked to hear about it. */
+  const NOTIFY_THROTTLE_MS = 10000;
+
   let socket = null;
   let attempt = 0;
   let waits = 0;
@@ -54,6 +60,12 @@ var tbxTransport = (() => {
   let welcomed = false; // has the live socket completed its handshake?
   let connecting = false; // a connect() is between reading the pairing and its socket
   let lastPairing = null; // {port, token} of the daemon the schedules apply to
+  let consecutiveFailures = 0; // closes since the last `welcome`
+  let lastCloseCode = null;
+  let lastCloseAt = null;
+  let lastWelcomeAt = null;
+  let onStateChange = null;
+  let lastNotifyAt = 0;
   const inFlight = new Map(); // request id -> AbortController-ish flag
 
   function state() {
@@ -66,6 +78,48 @@ var tbxTransport = (() => {
     // Open but unanswered is its own state, and the one worth reporting: it is
     // what a wedged handshake looks like from in here.
     return welcomed ? "connected" : "handshaking";
+  }
+
+  /**
+   * Everything `tbmcp doctor` needs when the bridge itself is what is broken.
+   *
+   * It ends up in <profile>/tbmcp-addon-status.json, which is the only channel
+   * left when no connection is working.
+   */
+  function status() {
+    return {
+      state: state(),
+      attempt,
+      inFlight: inFlight.size,
+      consecutiveFailures,
+      lastCloseCode,
+      lastCloseAt,
+      lastWelcomeAt,
+      port: currentPort,
+    };
+  }
+
+  /**
+   * @param {boolean} force  a transition worth reporting whatever the last one
+   *   cost — coming up is always news, a failure in a burst of them is not.
+   */
+  function notify(force) {
+    if (!onStateChange || stopped) {
+      return;
+    }
+    const at = Date.now();
+    if (!force) {
+      if (at - lastNotifyAt < NOTIFY_THROTTLE_MS) {
+        return;
+      }
+      lastNotifyAt = at;
+    }
+    try {
+      onStateChange(status());
+    } catch (ex) {
+      // Reporting our own state must not be able to break the connection.
+      tbxLog.debug("state listener failed:", ex.message || ex);
+    }
   }
 
   async function readPairing() {
@@ -182,6 +236,9 @@ var tbxTransport = (() => {
         attempt = 0;
         waits = 0;
         rejections = 0;
+        consecutiveFailures = 0;
+        lastWelcomeAt = new Date().toISOString();
+        notify(true);
         refreshIdentity();
         break;
       default:
@@ -279,7 +336,6 @@ var tbxTransport = (() => {
       socket = new WebSocket(url);
     } catch (ex) {
       socket = null;
-      currentPort = null;
       scheduleRetry(`WebSocket constructor failed: ${ex.message || ex}`, "failed");
       return;
     }
@@ -337,12 +393,30 @@ var tbxTransport = (() => {
       const hadWelcome = welcomed;
       welcomed = false;
       socket = null;
-      currentPort = null;
+      // currentPort survives the close on purpose: a status read after a failure
+      // is exactly when the port we were failing against matters.
       for (const ctx of inFlight.values()) {
         ctx.cancelled = true;
       }
       inFlight.clear();
       const code = event ? event.code : 1006;
+      const reason = (event && event.reason) || "";
+      lastCloseCode = code;
+      lastCloseAt = new Date().toISOString();
+      // Reported at info, not debug: a connection that keeps dropping is the one
+      // thing a user needs to be able to see without turning on verbose logging.
+      tbxLog.info(`socket closed (code ${code}: ${reason})`);
+
+      consecutiveFailures += 1;
+      if (consecutiveFailures === HANDSHAKE_ALARM_AFTER) {
+        // Once per run of failures. Saying it every time would bury it.
+        tbxLog.error(
+          `the daemon on port ${pairing.port} accepted ${consecutiveFailures} connections ` +
+            "but none completed the handshake — restart Thunderbird if this persists; " +
+            "`tbmcp doctor` shows the daemon's view"
+        );
+      }
+      notify(false);
 
       // A rejected token (4001) nearly always means the daemon we paired with has been
       // replaced and the file we read is stale — not that the install is broken. So
@@ -428,13 +502,16 @@ var tbxTransport = (() => {
     /**
      * @param {{app: object|null, capabilities: object|null}} [seed]  what main.js
      *   already fetched for the status file; either half may be null.
+     * @param {{onStateChange: (status: object) => void}} [options]  told when the
+     *   bridge comes up and when a connection fails.
      */
-    start(seed) {
+    start(seed, options) {
       stopped = false;
       identity = {
         app: (seed && seed.app) || null,
         capabilities: (seed && seed.capabilities) || null,
       };
+      onStateChange = (options && options.onStateChange) || null;
       connect();
       clearInterval(supervisor);
       supervisor = setInterval(supervise, SUPERVISE_MS);
@@ -455,8 +532,6 @@ var tbxTransport = (() => {
     emit(name, data) {
       send({ t: "event", name, data });
     },
-    status() {
-      return { state: state(), attempt, inFlight: inFlight.size };
-    },
+    status,
   };
 })();

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -33,6 +33,11 @@ var tbxTransport = (() => {
   let rejections = 0;
   let retryTimer = null;
   let stopped = false;
+  /* What `hello` announces about this Thunderbird. Kept here, ready to send,
+   * because the handshake must not wait on a probe: both probes cross into the
+   * privileged half, and one that never answers used to leave the socket open and
+   * silent until the daemon gave up on it. */
+  let identity = { app: null, capabilities: null };
   const inFlight = new Map(); // request id -> AbortController-ish flag
 
   function state() {
@@ -154,10 +159,28 @@ var tbxTransport = (() => {
         attempt = 0;
         waits = 0;
         rejections = 0;
+        refreshIdentity();
         break;
       default:
         break;
     }
+  }
+
+  /**
+   * Re-probe once the connection is up, so the next reconnect is not stale.
+   *
+   * Off the handshake path on purpose: this is where the slow calls live, and
+   * nothing waits for the answer. A probe that fails leaves the previous identity
+   * in place — a stale description is still better than none.
+   */
+  function refreshIdentity() {
+    Promise.all([tbxCapabilities.appInfo(), tbxCapabilities.describe()])
+      .then(([app, capabilities]) => {
+        identity = { app, capabilities };
+      })
+      .catch((ex) => {
+        tbxLog.debug("identity refresh failed:", ex.message || ex);
+      });
   }
 
   /** @param {"waiting"|"failed"} kind  which schedule to use. */
@@ -210,16 +233,15 @@ var tbxTransport = (() => {
       return;
     }
 
-    socket.onopen = async () => {
-      const hello = {
+    socket.onopen = () => {
+      send({
         t: "hello",
         token: pairing.token,
         protocol: PROTOCOL,
         addonVersion: browser.runtime.getManifest().version,
-        app: await tbxCapabilities.appInfo(),
-        capabilities: await tbxCapabilities.describe(),
-      };
-      send(hello);
+        app: identity.app || tbxCapabilities.appInfoSync(),
+        capabilities: identity.capabilities || tbxCapabilities.describeSync(),
+      });
     };
     socket.onmessage = onMessage;
     socket.onerror = () => {
@@ -313,8 +335,16 @@ var tbxTransport = (() => {
   }
 
   return {
-    start() {
+    /**
+     * @param {{app: object|null, capabilities: object|null}} [seed]  what main.js
+     *   already fetched for the status file; either half may be null.
+     */
+    start(seed) {
       stopped = false;
+      identity = {
+        app: (seed && seed.app) || null,
+        capabilities: (seed && seed.capabilities) || null,
+      };
       connect();
       clearInterval(supervisor);
       supervisor = setInterval(supervise, SUPERVISE_MS);

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -71,8 +71,8 @@ var tbxTransport = (() => {
   let lastWelcomeAt = null;
   let onStateChange = null;
   let lastNotifyAt = 0;
-  let pairingTimer = null;
   const inFlight = new Map(); // request id -> AbortController-ish flag
+  const pairingTimers = new Set(); // deadlines of reads still outstanding
 
   function state() {
     if (!socket) {
@@ -150,30 +150,36 @@ var tbxTransport = (() => {
   /**
    * `readPairing()` with a deadline, so an attempt always ends.
    *
-   * A late answer is dropped: this promise has already rejected, the attempt that
-   * was waiting on it has gone, and a retry is on its way — resolving now would
-   * open a second socket behind the live one.
+   * Everything here belongs to this one call. A read we gave up on can still answer
+   * later, by which time the next attempt is waiting on a deadline of its own — and
+   * a late answer that reached for a shared timer would disarm that one, which is
+   * the hang this deadline exists to prevent. So the late answer clears its own
+   * timer, sees that its call is over, and goes no further.
    */
   function readPairingWithin(ms) {
     return new Promise((resolve, reject) => {
-      clearTimeout(pairingTimer);
-      pairingTimer = setTimeout(() => {
+      let settled = false;
+      const timer = setTimeout(() => {
+        settled = true;
+        pairingTimers.delete(timer);
         tbxLog.error(
           `readBridgeFile did not answer within ${ms}ms — the privileged half of the ` +
             "add-on is not responding; `tbmcp doctor` shows the daemon's view"
         );
         reject(new Error(`readBridgeFile did not answer within ${ms}ms`));
       }, ms);
-      readPairing().then(
-        (pairing) => {
-          clearTimeout(pairingTimer);
-          resolve(pairing);
-        },
-        (ex) => {
-          clearTimeout(pairingTimer);
-          reject(ex);
+      pairingTimers.add(timer);
+
+      const answer = (settleWith) => (value) => {
+        clearTimeout(timer);
+        pairingTimers.delete(timer);
+        if (settled) {
+          return; // the deadline already answered for this call
         }
-      );
+        settled = true;
+        settleWith(value);
+      };
+      readPairing().then(answer(resolve), answer(reject));
     });
   }
 
@@ -581,7 +587,10 @@ var tbxTransport = (() => {
       stopped = true;
       clearTimeout(retryTimer);
       retryTimer = null;
-      clearTimeout(pairingTimer);
+      for (const timer of pairingTimers) {
+        clearTimeout(timer);
+      }
+      pairingTimers.clear();
       clearTimeout(helloTimer);
       clearTimeout(connectTimer);
       clearInterval(supervisor);

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -52,6 +52,8 @@ var tbxTransport = (() => {
   let helloTimer = null;
   let connectTimer = null;
   let welcomed = false; // has the live socket completed its handshake?
+  let connecting = false; // a connect() is between reading the pairing and its socket
+  let lastPairing = null; // {port, token} of the daemon the schedules apply to
   const inFlight = new Map(); // request id -> AbortController-ish flag
 
   function state() {
@@ -222,10 +224,27 @@ var tbxTransport = (() => {
     retryTimer = setTimeout(connect, delay);
   }
 
+  /**
+   * One attempt at a time.
+   *
+   * `attemptConnection` awaits the pairing read before it has a socket to show for
+   * itself, and both the supervisor and the retry timer can call in during that
+   * window — which is how two sockets to the same daemon came about, one of them
+   * invisible to everything that inspects `socket`.
+   */
   async function connect() {
-    if (stopped || (socket && socket.readyState <= WebSocket.OPEN)) {
+    if (stopped || connecting || (socket && socket.readyState <= WebSocket.OPEN)) {
       return;
     }
+    connecting = true;
+    try {
+      await attemptConnection();
+    } finally {
+      connecting = false;
+    }
+  }
+
+  async function attemptConnection() {
     let pairing;
     try {
       pairing = await readPairing();
@@ -236,11 +255,22 @@ var tbxTransport = (() => {
       return;
     }
 
-    // The pairing file exists, so we are no longer waiting for a daemon to appear.
-    // Resetting here matters: after a long stretch with no daemon the wait counter
-    // sits at its ceiling, and a freshly written pairing file would otherwise not be
-    // acted on for seconds.
-    waits = 0;
+    // A daemon we have not tried before gets both schedules back at zero: after a
+    // long stretch with no daemon the counters sit at their ceiling, and a freshly
+    // written pairing file would otherwise not be acted on for half a minute.
+    //
+    // The same file we have been failing against does not get that: it is the one
+    // that used to leave us reconnecting every half second for as long as
+    // Thunderbird stayed up.
+    if (
+      !lastPairing ||
+      lastPairing.port !== pairing.port ||
+      lastPairing.token !== pairing.token
+    ) {
+      waits = 0;
+      attempt = 0;
+    }
+    lastPairing = { port: pairing.port, token: pairing.token };
 
     const url = `ws://127.0.0.1:${pairing.port}/tbmcp`;
     tbxLog.debug(`connecting to ${url}`);
@@ -297,8 +327,15 @@ var tbxTransport = (() => {
       tbxLog.debug("socket error");
     };
     ws.onclose = (event) => {
+      if (socket !== ws) {
+        // A socket we have already moved on from. Acting on this would null the
+        // live one and leave nothing to notice.
+        return;
+      }
       clearTimeout(helloTimer);
       clearTimeout(connectTimer);
+      const hadWelcome = welcomed;
+      welcomed = false;
       socket = null;
       currentPort = null;
       for (const ctx of inFlight.values()) {
@@ -339,9 +376,10 @@ var tbxTransport = (() => {
             "`tbmcp install-addon`."
         );
       }
-      // 4000 is ours: a watchdog gave up on this socket. Whatever is on that port
-      // is not talking to us, so back off rather than poll.
-      scheduleRetry(`closed ${code}`, code === 4002 || code === 4000 ? "failed" : "waiting");
+      // Which schedule applies is decided by how far this socket got, not by the
+      // code: a socket that never reached `welcome` means the daemon is there and
+      // not talking to us, and polling that every half second helps nobody.
+      scheduleRetry(`closed ${code}`, hadWelcome ? "waiting" : "failed");
     };
   }
 

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -12,13 +12,13 @@ var tbxTransport = (() => {
   const CHUNK_SIZE = 3 * 1024 * 1024; // stay under the daemon's 4 MiB frame ceiling
   /* Two schedules, because the two failure modes are nothing alike.
    *
-   * "No pairing file" is the normal resting state: no daemon has started yet. The
-   * check is a local file stat, so polling it briskly costs nothing — and backing
-   * off here is what made a freshly started daemon wait up to half a minute before
-   * anything worked.
+   * Waiting is the normal resting state: no daemon has started yet, or one that was
+   * working has gone. The check is a local file stat, so polling it briskly costs
+   * nothing — and backing off here is what made a freshly started daemon wait up to
+   * half a minute before anything worked.
    *
-   * A failed connection is different: something is listening or the port is wrong,
-   * and hammering it helps nobody. */
+   * A failed connection is different: something is listening and not completing the
+   * handshake, and hammering it helps nobody. */
   const WAIT_MS = [500, 1000, 1000, 2000, 2000];
   const BACKOFF_MS = [500, 1000, 2000, 4000, 8000, 15000, 30000];
 
@@ -41,6 +41,11 @@ var tbxTransport = (() => {
 
   /** Floor on how often the state is pushed out to whoever asked to hear about it. */
   const NOTIFY_THROTTLE_MS = 10000;
+
+  /* A read that never settles used to be terminal: nothing clears `connecting`, so
+   * no later attempt can start, and no retry was ever armed to try again. The
+   * privileged half is exactly the part that wedges, so the read gets a deadline. */
+  const PAIRING_TIMEOUT_MS = 5000;
 
   let socket = null;
   let attempt = 0;
@@ -66,6 +71,7 @@ var tbxTransport = (() => {
   let lastWelcomeAt = null;
   let onStateChange = null;
   let lastNotifyAt = 0;
+  let pairingTimer = null;
   const inFlight = new Map(); // request id -> AbortController-ish flag
 
   function state() {
@@ -89,6 +95,9 @@ var tbxTransport = (() => {
   function status() {
     return {
       state: state(),
+      // Separate from `state`, which is about the socket: this one says an attempt
+      // is waiting on the privileged half, which is where a wedge shows up first.
+      connecting,
       attempt,
       inFlight: inFlight.size,
       consecutiveFailures,
@@ -136,6 +145,36 @@ var tbxTransport = (() => {
       );
     }
     return pairing;
+  }
+
+  /**
+   * `readPairing()` with a deadline, so an attempt always ends.
+   *
+   * A late answer is dropped: this promise has already rejected, the attempt that
+   * was waiting on it has gone, and a retry is on its way — resolving now would
+   * open a second socket behind the live one.
+   */
+  function readPairingWithin(ms) {
+    return new Promise((resolve, reject) => {
+      clearTimeout(pairingTimer);
+      pairingTimer = setTimeout(() => {
+        tbxLog.error(
+          `readBridgeFile did not answer within ${ms}ms — the privileged half of the ` +
+            "add-on is not responding; `tbmcp doctor` shows the daemon's view"
+        );
+        reject(new Error(`readBridgeFile did not answer within ${ms}ms`));
+      }, ms);
+      readPairing().then(
+        (pairing) => {
+          clearTimeout(pairingTimer);
+          resolve(pairing);
+        },
+        (ex) => {
+          clearTimeout(pairingTimer);
+          reject(ex);
+        }
+      );
+    });
   }
 
   function send(message) {
@@ -309,7 +348,7 @@ var tbxTransport = (() => {
   async function attemptConnection() {
     let pairing;
     try {
-      pairing = await readPairing();
+      pairing = await readPairingWithin(PAIRING_TIMEOUT_MS);
     } catch (ex) {
       const message = String(ex.message || ex);
       // No pairing file is the resting state, not a failure: poll, do not back off.
@@ -317,12 +356,13 @@ var tbxTransport = (() => {
       return;
     }
 
-    // A daemon we have not tried before gets both schedules back at zero: after a
-    // long stretch with no daemon the counters sit at their ceiling, and a freshly
-    // written pairing file would otherwise not be acted on for half a minute.
+    // A daemon we have not tried before starts with a clean slate: after a long
+    // stretch with no daemon the counters sit at their ceiling, and a freshly
+    // written pairing file would otherwise not be acted on for half a minute — or
+    // would be blamed, on its first close, for the previous daemon's failures.
     //
-    // The same file we have been failing against does not get that: it is the one
-    // that used to leave us reconnecting every half second for as long as
+    // The same file we have been failing against gets no such reprieve: it is the
+    // one that used to leave us reconnecting every half second for as long as
     // Thunderbird stayed up.
     if (
       !lastPairing ||
@@ -331,6 +371,7 @@ var tbxTransport = (() => {
     ) {
       waits = 0;
       attempt = 0;
+      consecutiveFailures = 0;
     }
     lastPairing = { port: pairing.port, token: pairing.token };
 
@@ -429,9 +470,10 @@ var tbxTransport = (() => {
       notify(false);
 
       // A rejected token (4001) nearly always means the daemon we paired with has been
-      // replaced and the file we read is stale — not that the install is broken. So
-      // re-read and try again promptly, and only complain after several rounds have
-      // failed with the file we just read.
+      // replaced and the file we read is stale — not that the install is broken. The
+      // next attempt re-reads the file, and a file that has changed resets the
+      // counters, so a replacement daemon is reached quickly; only a run of
+      // rejections against the file we keep reading is worth complaining about.
       if (code === 4001) {
         rejections += 1;
         if (rejections >= 4) {
@@ -446,13 +488,8 @@ var tbxTransport = (() => {
         rejections = 0;
       }
 
-      // Almost every other close means the daemon went away: it exited on its idle
-      // timer (1000/1001), was superseded (1012), or its process died and took the
-      // socket with it (1006). In all of those the right response is to poll for a new
-      // pairing file, not to back off — the next daemon may be seconds away and the
-      // check is a local file stat.
-      //
-      // Only a protocol mismatch is worth backing off for: that will not fix itself.
+      // A protocol mismatch will not fix itself, so say so rather than retrying
+      // quietly for the rest of the session.
       if (code === 4002) {
         tbxLog.error(
           `daemon rejected the connection (code ${code}: ${event && event.reason}). ` +
@@ -460,9 +497,19 @@ var tbxTransport = (() => {
             "`tbmcp install-addon`."
         );
       }
-      // Which schedule applies is decided by how far this socket got, not by the
-      // code: a socket that never reached `welcome` means the daemon is there and
-      // not talking to us, and polling that every half second helps nobody.
+      /* Which schedule applies is decided by how far this socket got, not by the
+       * code it closed with:
+       *
+       * - never welcomed: something is listening and not talking to us, whatever it
+       *   says on the way out, so back off (BACKOFF_MS) instead of dialling it every
+       *   half second for as long as Thunderbird is up;
+       * - welcomed, then closed: the daemon went away — it exited on its idle timer
+       *   (1000/1001), was superseded (1012), or died with the socket (1006) — and
+       *   the next one may be seconds away, so poll (WAIT_MS); the check is a local
+       *   file stat and costs nothing.
+       *
+       * Either way, a pairing file that has changed resets both counters, so a new
+       * daemon never waits out the previous one's backoff (see attemptConnection). */
       scheduleRetry(`closed ${code}`, hadWelcome ? "waiting" : "failed");
     };
   }
@@ -534,6 +581,7 @@ var tbxTransport = (() => {
       stopped = true;
       clearTimeout(retryTimer);
       retryTimer = null;
+      clearTimeout(pairingTimer);
       clearTimeout(helloTimer);
       clearTimeout(connectTimer);
       clearInterval(supervisor);

--- a/addon/background/transport.js
+++ b/addon/background/transport.js
@@ -25,6 +25,17 @@ var tbxTransport = (() => {
   /** How often to re-check that we are still attached to the advertised daemon. */
   const SUPERVISE_MS = 10000;
 
+  /* An open socket that never gets its `welcome` is the worst state to be in: it
+   * looks connected from here, answers nothing, and used to sit there until the
+   * daemon's own timeout dropped it — silently, on repeat, for as long as
+   * Thunderbird stayed up. Give up on it ourselves, and say so. */
+  const HELLO_TIMEOUT_MS = 8000;
+
+  /* And the same for the step before it. A socket that reaches TCP but never
+   * completes the HTTP upgrade stays CONNECTING forever as far as Gecko is
+   * concerned — no error event, no close — so nothing else would ever free it. */
+  const CONNECT_TIMEOUT_MS = 15000;
+
   let socket = null;
   let attempt = 0;
   let waits = 0;
@@ -38,13 +49,21 @@ var tbxTransport = (() => {
    * privileged half, and one that never answers used to leave the socket open and
    * silent until the daemon gave up on it. */
   let identity = { app: null, capabilities: null };
+  let helloTimer = null;
+  let connectTimer = null;
+  let welcomed = false; // has the live socket completed its handshake?
   const inFlight = new Map(); // request id -> AbortController-ish flag
 
   function state() {
     if (!socket) {
       return "disconnected";
     }
-    return socket.readyState === WebSocket.OPEN ? "connected" : "connecting";
+    if (socket.readyState !== WebSocket.OPEN) {
+      return "connecting";
+    }
+    // Open but unanswered is its own state, and the one worth reporting: it is
+    // what a wedged handshake looks like from in here.
+    return welcomed ? "connected" : "handshaking";
   }
 
   async function readPairing() {
@@ -156,6 +175,8 @@ var tbxTransport = (() => {
         break;
       case "welcome":
         tbxLog.info("bridge established");
+        clearTimeout(helloTimer);
+        welcomed = true;
         attempt = 0;
         waits = 0;
         rejections = 0;
@@ -233,7 +254,26 @@ var tbxTransport = (() => {
       return;
     }
 
-    socket.onopen = () => {
+    // Handlers bind to this socket rather than to whatever `socket` holds when they
+    // fire, so a late event from a superseded socket cannot disturb the live one.
+    const ws = socket;
+    welcomed = false;
+
+    clearTimeout(connectTimer);
+    connectTimer = setTimeout(() => {
+      if (ws.readyState !== WebSocket.CONNECTING) {
+        return;
+      }
+      tbxLog.error(
+        `no WebSocket handshake with the daemon on port ${pairing.port} within ` +
+          `${CONNECT_TIMEOUT_MS}ms — closing the socket; \`tbmcp doctor\` shows the ` +
+          "daemon's view"
+      );
+      ws.close(4000, "connect timeout");
+    }, CONNECT_TIMEOUT_MS);
+
+    ws.onopen = () => {
+      clearTimeout(connectTimer);
       send({
         t: "hello",
         token: pairing.token,
@@ -242,13 +282,23 @@ var tbxTransport = (() => {
         app: identity.app || tbxCapabilities.appInfoSync(),
         capabilities: identity.capabilities || tbxCapabilities.describeSync(),
       });
+      clearTimeout(helloTimer);
+      helloTimer = setTimeout(() => {
+        tbxLog.error(
+          `no welcome from the daemon within ${HELLO_TIMEOUT_MS}ms after hello — closing ` +
+            "the socket; `tbmcp doctor` shows the daemon's view"
+        );
+        ws.close(4000, "no welcome");
+      }, HELLO_TIMEOUT_MS);
     };
-    socket.onmessage = onMessage;
-    socket.onerror = () => {
+    ws.onmessage = onMessage;
+    ws.onerror = () => {
       // onclose always follows; retry is scheduled there.
       tbxLog.debug("socket error");
     };
-    socket.onclose = (event) => {
+    ws.onclose = (event) => {
+      clearTimeout(helloTimer);
+      clearTimeout(connectTimer);
       socket = null;
       currentPort = null;
       for (const ctx of inFlight.values()) {
@@ -289,7 +339,9 @@ var tbxTransport = (() => {
             "`tbmcp install-addon`."
         );
       }
-      scheduleRetry(`closed ${code}`, code === 4002 ? "failed" : "waiting");
+      // 4000 is ours: a watchdog gave up on this socket. Whatever is on that port
+      // is not talking to us, so back off rather than poll.
+      scheduleRetry(`closed ${code}`, code === 4002 || code === 4000 ? "failed" : "waiting");
     };
   }
 
@@ -352,6 +404,8 @@ var tbxTransport = (() => {
     stop() {
       stopped = true;
       clearTimeout(retryTimer);
+      clearTimeout(helloTimer);
+      clearTimeout(connectTimer);
       clearInterval(supervisor);
       supervisor = null;
       if (socket) {

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -231,6 +231,13 @@ const H = {
     }
   },
 
+  /** Who we are, recorded by getAPI() because `context` reaches nowhere else.
+   *
+   *  `admin.consoleMessages` needs it to tell our own console output apart from
+   *  every other add-on's in the shared ConsoleAPI store. Undefined until the API
+   *  is built, so anything reading it must cope with that. */
+  extension: null,
+
   /** Wrap a callback-style Thunderbird API as a promise with a deadline. */
   withTimeout(promise, ms, what) {
     let timer = null;
@@ -329,6 +336,16 @@ this.tbx = class extends ExtensionAPI {
   }
 
   getAPI(context) {
+    // The only place the privileged half ever sees its own identity; keep it
+    // where the modules can reach it (see H.extension).
+    try {
+      H.extension = {
+        id: context.extension.id,
+        baseURL: String(context.extension.baseURL || ""),
+      };
+    } catch (ex) {
+      H.extension = null;
+    }
     return {
       tbx: wired({
         /* -------------------------------------------------- bridge plumbing */

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -277,6 +277,27 @@ function wireError(ex) {
   return { message };
 }
 
+/**
+ * Put every method of the API surface behind `wireError`.
+ *
+ * Applied once to the whole namespace rather than method by method, so a method
+ * added later cannot forget: the boundary is a property of the surface, not of
+ * any one call. `invoke` therefore does no wrapping of its own.
+ */
+function wired(api) {
+  const out = {};
+  for (const [name, fn] of Object.entries(api)) {
+    out[name] = async (...args) => {
+      try {
+        return await fn(...args);
+      } catch (ex) {
+        throw wireError(ex);
+      }
+    };
+  }
+  return out;
+}
+
 /* --------------------------------------------------------------- dispatch table */
 
 /** Privileged handlers, keyed by the method name minus its "x." prefix.
@@ -309,7 +330,7 @@ this.tbx = class extends ExtensionAPI {
 
   getAPI(context) {
     return {
-      tbx: {
+      tbx: wired({
         /* -------------------------------------------------- bridge plumbing */
 
         async readBridgeFile() {
@@ -507,19 +528,14 @@ this.tbx = class extends ExtensionAPI {
          * `browser.tbx.invoke("prefs.get", params)`.
          */
         async invoke(method, params) {
-          try {
-            const handler = TBX_MODULES[method];
-            if (!handler) {
-              const known = Object.keys(TBX_MODULES).sort().join(", ");
-              throw H.usage(`unknown privileged method ${method} (known: ${known})`);
-            }
-            // Awaited, not returned: a rejection has to reach the catch below.
-            return await handler(params || {});
-          } catch (ex) {
-            throw wireError(ex);
+          const handler = TBX_MODULES[method];
+          if (!handler) {
+            const known = Object.keys(TBX_MODULES).sort().join(", ");
+            throw H.usage(`unknown privileged method ${method} (known: ${known})`);
           }
+          return handler(params || {});
         },
-      },
+      }),
     };
   }
 };

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -22,6 +22,16 @@
 
 "use strict";
 
+/* ------------------------------------------------------------------- timers */
+
+/* The sandbox has no DOM globals, so the bare `setTimeout` every deadline here
+ * used to call was a ReferenceError: it rejected the deadline promise before the
+ * work it guarded had started, which took out gloda search entirely. Chrome code
+ * gets its timers from the platform's Timer module instead. */
+const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
+  "resource://gre/modules/Timer.sys.mjs"
+);
+
 /* ------------------------------------------------------------------ modules */
 
 /** Module URLs as they exist on Thunderbird 128–153. Resolution is lazy so a
@@ -222,12 +232,13 @@ const H = {
 
   /** Wrap a callback-style Thunderbird API as a promise with a deadline. */
   withTimeout(promise, ms, what) {
-    return Promise.race([
-      promise,
-      new Promise((_resolve, reject) =>
-        setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms)
-      ),
-    ]);
+    let timer = null;
+    const deadline = new Promise((_resolve, reject) => {
+      timer = setTimeout(() => reject(new Error(`${what} timed out after ${ms}ms`)), ms);
+    });
+    // Whichever way the race lands, the timer has to go: an armed one holds the
+    // deadline's rejection alive and keeps Thunderbird awake for nothing.
+    return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
   },
 };
 
@@ -472,3 +483,11 @@ this.tbx = class extends ExtensionAPI {
     };
   }
 };
+
+/* Block-scoped helpers, published for the add-on's tests.
+ *
+ * `TBX_TEST_HOOKS` does not exist in Thunderbird, so this statement is a no-op
+ * there — which is the point: no test-only branch ships inside a handler. */
+if (typeof TBX_TEST_HOOKS !== "undefined") {
+  TBX_TEST_HOOKS.core = { H, mod, needMod };
+}

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -34,7 +34,7 @@ const { setTimeout, clearTimeout } = ChromeUtils.importESModule(
 
 /* ------------------------------------------------------------------ modules */
 
-/** Module URLs as they exist on Thunderbird 128–153. Resolution is lazy so a
+/** Module URLs as they exist on Thunderbird 128–155. Resolution is lazy so a
  *  rename in a future release degrades one capability instead of the add-on. */
 const MODULE_URLS = {
   ExtensionPermissions: "resource://gre/modules/ExtensionPermissions.sys.mjs",

--- a/addon/experiment/core.js
+++ b/addon/experiment/core.js
@@ -56,6 +56,7 @@ const MODULE_URLS = {
   AddonManager: "resource://gre/modules/AddonManager.sys.mjs",
   NetUtil: "resource://gre/modules/NetUtil.sys.mjs",
   FileUtils: "resource://gre/modules/FileUtils.sys.mjs",
+  ExtensionUtils: "resource://gre/modules/ExtensionUtils.sys.mjs",
 };
 
 const _moduleCache = new Map();
@@ -241,6 +242,40 @@ const H = {
     return Promise.race([promise, deadline]).finally(() => clearTimeout(timer));
   },
 };
+
+/* ---------------------------------------------------------- errors on the wire */
+
+/** Marks a message as carrying our envelope; background/registry.js unpacks it. */
+const TBX_ERROR_TAG = "tbxerr:";
+
+/**
+ * Re-mint a failure as something that survives the hop to the background page.
+ *
+ * `ExtensionCommon.normalizeError` keeps a message only for a plain object, an
+ * `ExtensionError`, or an error whose principal the extension subsumes. Ours is
+ * none of those — a plain `Error` minted with the system principal — so the
+ * background page was handed "An unexpected error occurred" and the whole
+ * taxonomy was lost. Serialise it into the one field that does get through.
+ */
+function wireError(ex) {
+  const payload = {
+    kind: (ex && ex.tbxKind) || "thunderbird",
+    message: String((ex && ex.message) || ex),
+    // A bare "Error" name says nothing; a subclass or an explicit code does.
+    code: (ex && ex.code) || (ex && ex.name && ex.name !== "Error" ? ex.name : null),
+  };
+  if (ex && ex.needs !== undefined && ex.needs !== null) {
+    payload.needs = [].concat(ex.needs);
+  }
+  const message = TBX_ERROR_TAG + JSON.stringify(payload);
+  const utils = mod("ExtensionUtils");
+  if (utils && utils.ExtensionError) {
+    return new utils.ExtensionError(message);
+  }
+  // The other shape normalizeError trusts. Worth keeping: without ExtensionError
+  // every privileged failure would go back to being unreadable.
+  return { message };
+}
 
 /* --------------------------------------------------------------- dispatch table */
 
@@ -472,12 +507,17 @@ this.tbx = class extends ExtensionAPI {
          * `browser.tbx.invoke("prefs.get", params)`.
          */
         async invoke(method, params) {
-          const handler = TBX_MODULES[method];
-          if (!handler) {
-            const known = Object.keys(TBX_MODULES).sort().join(", ");
-            throw H.usage(`unknown privileged method ${method} (known: ${known})`);
+          try {
+            const handler = TBX_MODULES[method];
+            if (!handler) {
+              const known = Object.keys(TBX_MODULES).sort().join(", ");
+              throw H.usage(`unknown privileged method ${method} (known: ${known})`);
+            }
+            // Awaited, not returned: a rejection has to reach the catch below.
+            return await handler(params || {});
+          } catch (ex) {
+            throw wireError(ex);
           }
-          return handler(params || {});
         },
       },
     };
@@ -489,5 +529,5 @@ this.tbx = class extends ExtensionAPI {
  * `TBX_TEST_HOOKS` does not exist in Thunderbird, so this statement is a no-op
  * there — which is the point: no test-only branch ships inside a handler. */
 if (typeof TBX_TEST_HOOKS !== "undefined") {
-  TBX_TEST_HOOKS.core = { H, mod, needMod };
+  TBX_TEST_HOOKS.core = { H, mod, needMod, wireError, handlers: TBX_MODULES };
 }

--- a/addon/experiment/modules/admin.js
+++ b/addon/experiment/modules/admin.js
@@ -452,6 +452,82 @@ TBX_MODULE_NAMES.push("admin");
     return record;
   }
 
+  /** Whether a ConsoleAPI event came from this add-on's own pages.
+   *
+   *  The store is shared by every extension, so an event is ours only when it
+   *  carries our add-on id, or — for pages that report no id — an innerID under
+   *  our moz-extension:// base URL. With no identity recorded yet nothing can be
+   *  claimed, so nothing is. */
+  function ownConsoleEvent(event) {
+    const who = H.extension;
+    if (!who || !event) {
+      return false;
+    }
+    if (event.addonId) {
+      return event.addonId === who.id;
+    }
+    const inner = typeof event.innerID === "string" ? event.innerID : "";
+    return Boolean(who.baseURL) && inner.startsWith(who.baseURL);
+  }
+
+  /** The add-on's own `console.*` output, in the same record shape as the
+   *  nsIConsoleMessage entries.
+   *
+   *  An extension page's console output goes to the ConsoleAPI storage, not to
+   *  Services.console — which is why `tb_console` never showed a single `[tbmcp]`
+   *  line, the one thing it exists to surface. Best effort: a build without the
+   *  service, or one that refuses us, just contributes nothing. */
+  function ownConsoleEvents() {
+    let events;
+    try {
+      events = Cc["@mozilla.org/consoleAPI-storage;1"]
+        .getService(Ci.nsIConsoleAPIStorage)
+        .getEvents();
+    } catch (ex) {
+      return [];
+    }
+    const records = [];
+    for (const event of events || []) {
+      if (!ownConsoleEvent(event)) {
+        continue;
+      }
+      let text;
+      try {
+        text = Array.from(event.arguments || [], (arg) =>
+          typeof arg === "string" ? arg : JSON.stringify(arg)
+        ).join(" ");
+      } catch (ex) {
+        text = `<unreadable console event: ${ex.message || ex}>`;
+      }
+      const record = {
+        message: redact(text),
+        severity: String(event.level || "log"),
+        source: "console",
+      };
+      if (event.timeStamp) {
+        record.at = new Date(event.timeStamp).toISOString();
+      }
+      records.push(record);
+    }
+    return records;
+  }
+
+  /** Records from both stores in time order, newest last. Entries without a
+   *  timestamp keep their store's own order and sort as oldest. */
+  function mergedConsole(entries) {
+    const stamped = (record, index) => ({
+      record,
+      index,
+      time: record.at ? Date.parse(record.at) : 0,
+    });
+    const rows = entries
+      .map(describeConsoleEntry)
+      .map(stamped)
+      .concat(ownConsoleEvents().map((record, index) => stamped(record, entries.length + index)));
+    rows.sort((a, b) => a.time - b.time || a.index - b.index);
+    return rows.map((row) => row.record);
+  }
+
   TBX_MODULES["admin.consoleMessages"] = async (params) => {
     const limit = Number.isInteger(params.limit) ? Math.min(Math.max(params.limit, 1), 500) : 100;
     const filter = params.filter ? String(params.filter).toLowerCase() : null;
@@ -461,20 +537,19 @@ TBX_MODULE_NAMES.push("admin");
     } catch (ex) {
       throw H.unsupported(`the error console is not readable: ${ex.message || ex}`);
     }
+    const records = mergedConsole(entries);
     const matched = [];
-    for (const entry of entries) {
-      const record = describeConsoleEntry(entry);
+    for (const record of records) {
       if (filter && !record.message.toLowerCase().includes(filter)) {
         continue;
       }
       matched.push(record);
     }
-    // Newest last: that is the order the console keeps them in, and reading a tail
-    // top to bottom is how anyone actually debugs.
+    // Newest last: reading a tail top to bottom is how anyone actually debugs.
     return {
       messages: matched.slice(-limit),
       matched: matched.length,
-      buffered: entries.length,
+      buffered: records.length,
       filter: params.filter || null,
     };
   };

--- a/addon/experiment/modules/admin.js
+++ b/addon/experiment/modules/admin.js
@@ -446,8 +446,16 @@ TBX_MODULE_NAMES.push("admin");
       }
     } catch (ex) {
       // A plain nsIConsoleMessage — console.log output and XPCOM warnings — carries
-      // no location, so the text is all there is.
+      // no location, but it does carry its time, and without it the merge below
+      // would file every such line as "oldest" and trim it first.
       record.severity = "message";
+      try {
+        if (entry.timeStamp) {
+          record.at = new Date(entry.timeStamp).toISOString();
+        }
+      } catch (timeError) {
+        // No time at all: the store's own order is the best we have.
+      }
     }
     return record;
   }
@@ -512,18 +520,26 @@ TBX_MODULE_NAMES.push("admin");
     return records;
   }
 
-  /** Records from both stores in time order, newest last. Entries without a
-   *  timestamp keep their store's own order and sort as oldest. */
+  /** Records from both stores in time order, newest last.
+   *
+   *  An entry with no time keeps its position relative to its neighbours by
+   *  borrowing the time of the previous entry in its own store — the store is
+   *  already chronological, so that is where it belongs, and it can never be
+   *  pushed to the front where `limit` would trim it away. */
   function mergedConsole(entries) {
-    const stamped = (record, index) => ({
-      record,
-      index,
-      time: record.at ? Date.parse(record.at) : 0,
-    });
-    const rows = entries
-      .map(describeConsoleEntry)
-      .map(stamped)
-      .concat(ownConsoleEvents().map((record, index) => stamped(record, entries.length + index)));
+    const stamped = (records, offset) => {
+      let last = 0;
+      return records.map((record, index) => {
+        const parsed = record.at ? Date.parse(record.at) : NaN;
+        if (Number.isFinite(parsed)) {
+          last = parsed;
+        }
+        return { record, index: offset + index, time: last };
+      });
+    };
+    const rows = stamped(entries.map(describeConsoleEntry), 0).concat(
+      stamped(ownConsoleEvents(), entries.length)
+    );
     rows.sort((a, b) => a.time - b.time || a.index - b.index);
     return rows.map((row) => row.record);
   }

--- a/addon/experiment/modules/gloda.js
+++ b/addon/experiment/modules/gloda.js
@@ -290,6 +290,27 @@ TBX_MODULE_NAMES.push("gloda");
     return Services.prefs.getBoolPref("mailnews.database.global.indexer.enabled", false);
   }
 
+  /**
+   * Split search terms into the ones the index can match and the ones it cannot.
+   *
+   * The tokenizer keeps only tokens of three characters or more (one for CJK), so
+   * a term like "2.0" becomes "2" and "0" and is dropped entirely. Under AND that
+   * one term zeroes the whole query, silently — which is worth reporting, because
+   * the answer looks exactly like "nothing matched".
+   */
+  function classifyTerms(terms) {
+    const usable = [];
+    const unmatchable = [];
+    for (const term of terms || []) {
+      const tokens = String(term)
+        .split(/[^\p{L}\p{N}]+/u)
+        .filter(Boolean);
+      const matches = tokens.some((token) => token.length >= 3 || token.charCodeAt(0) >= 0x2000);
+      (matches ? usable : unmatchable).push(term);
+    }
+    return { usable, unmatchable };
+  }
+
   // ------------------------------------------------------------------- search
 
   TBX_MODULES["gloda.search"] = async (params) => {
@@ -303,13 +324,8 @@ TBX_MODULE_NAMES.push("gloda");
     const Searcher = needMod("GlodaMsgSearcher");
 
     const searcher = new Searcher(null, query, params.matchAll !== false);
-    // The tokenizer drops terms shorter than three characters (one or two for
-    // CJK), so a query made only of those silently matches everything or
-    // nothing. Say so instead.
-    const usable = (searcher.fulltextTerms || []).some(
-      (term) => term.length >= 3 || term.charCodeAt(0) >= 0x2000
-    );
-    if (!usable) {
+    const { usable, unmatchable } = classifyTerms(searcher.fulltextTerms);
+    if (!usable.length) {
       throw H.usage(
         `no searchable term in ${JSON.stringify(query)} — the global index needs ` +
           "terms of at least three characters (one for CJK)"
@@ -329,16 +345,22 @@ TBX_MODULE_NAMES.push("gloda");
         // ours nests inside it.
         searcher.listener = listener;
         searcher.query = searcher.buildFulltextQuery();
-        searcher.query.limit(retrieve);
+        // One row past what we need: the only way to know whether the corpus was
+        // deeper than the retrieval, without calling a corpus that exactly fills
+        // it truncated.
+        searcher.query.limit(retrieve + 1);
         searcher.collection = searcher.query.getCollection(searcher, null);
       },
       "gloda search",
       SEARCH_TIMEOUT_MS
     );
 
+    const truncated = messages.length > retrieve;
+    const considered = truncated ? messages.slice(0, retrieve) : messages;
+
     // searcher.scores accumulates in the order items were handed to us.
     const scores = searcher.scores || [];
-    let hits = messages.map((message, index) => hit(message, scores[index]));
+    let hits = considered.map((message, index) => hit(message, scores[index]));
     if (inFolder) {
       hits = hits.filter(inFolder);
     }
@@ -349,17 +371,30 @@ TBX_MODULE_NAMES.push("gloda");
       query,
       hits: hits.slice(offset, offset + limit),
       matched: hits.length,
-      retrieved: messages.length,
+      retrieved: considered.length,
       // The ranking only ordered what we retrieved; a deeper page may reorder.
-      truncated: messages.length >= retrieve,
+      truncated,
       indexEnabled: enabled,
     };
+    if (unmatchable.length) {
+      result.unmatchableTerms = unmatchable;
+    }
     if (!result.hits.length) {
-      result.note = enabled
-        ? "Nothing in the global index matched. Only indexed messages are searchable — " +
-          "check x.gloda.stats, or fall back to mail_search with subject/author filters."
-        : "Thunderbird's global index is disabled, so this search can never match. " +
+      if (!enabled) {
+        result.note =
+          "Thunderbird's global index is disabled, so this search can never match. " +
           "Enable it in Settings > General > Indexing, or use mail_search instead.";
+      } else if (unmatchable.length) {
+        const named = unmatchable.map((term) => JSON.stringify(term)).join(", ");
+        result.note =
+          `The index cannot match ${named} — it tokenizes into pieces shorter than ` +
+          "three characters, and every term has to match. Drop those words and search " +
+          "again, or use mail_search with a subject filter.";
+      } else {
+        result.note =
+          "Nothing in the global index matched. Only indexed messages are searchable — " +
+          "check x.gloda.stats, or fall back to mail_search with subject/author filters.";
+      }
     }
     return result;
   };
@@ -537,6 +572,6 @@ TBX_MODULE_NAMES.push("gloda");
 
   /* Pure helpers, published for the add-on's tests; see the note in core.js. */
   if (typeof TBX_TEST_HOOKS !== "undefined") {
-    TBX_TEST_HOOKS.gloda = { isoDate, folderMatcher };
+    TBX_TEST_HOOKS.gloda = { classifyTerms, folderMatcher, isoDate };
   }
 }

--- a/addon/experiment/modules/gloda.js
+++ b/addon/experiment/modules/gloda.js
@@ -130,29 +130,41 @@ TBX_MODULE_NAMES.push("gloda");
     }
   }
 
-  /** Accept a WebExtension folder id or a raw folder URI; gloda speaks URIs. */
-  function folderRefToUri(ref) {
+  /** An account's root folder URI, or null if this account cannot say. */
+  function rootUri(account) {
+    try {
+      return account.incomingServer.rootFolder.URI;
+    } catch (ex) {
+      return null;
+    }
+  }
+
+  /**
+   * A predicate over hits for one folder reference.
+   *
+   * A WebExtension folder id (`account1://INBOX`) and a folder URI
+   * (`imap://me@example.com/INBOX`) both contain `://`, so the only way to tell
+   * them apart is to ask which accounts exist — the id's prefix is an account
+   * key, the URI's is a scheme. Translating the id to a URI is what used to
+   * happen, and it produced `imap://…//INBOX`, which matched nothing at all.
+   * Each hit already carries both, so match on whichever the caller named.
+   */
+  function folderMatcher(ref) {
     const text = String(ref).trim();
-    if (text.includes("://")) {
-      return text;
-    }
     const cut = text.indexOf(":/");
-    if (cut < 1) {
-      throw H.usage(
-        `${text} is not a folder id — pass one returned by folder_list, or a folder URI`
-      );
+    const key = cut > 0 ? text.slice(0, cut) : "";
+    for (const account of needMod("MailServices").accounts.accounts) {
+      if (account.key === key) {
+        return (entry) => entry.folderId === text;
+      }
+      const root = rootUri(account);
+      if (root && (text === root || text.startsWith(`${root}/`))) {
+        return (entry) => entry.folderUri === text;
+      }
     }
-    const accounts = extensionAccounts();
-    if (!accounts || !accounts.folderPathToURI) {
-      throw H.unsupported(
-        "this build cannot translate folder ids to folder URIs; pass a folder URI instead"
-      );
-    }
-    const uri = accounts.folderPathToURI(text.slice(0, cut), text.slice(cut + 1));
-    if (!uri) {
-      throw H.usage(`no account with key ${text.slice(0, cut)}`);
-    }
-    return uri;
+    throw H.usage(
+      `${text} names no folder in this profile — pass an id from folder_list, or a folder URI`
+    );
   }
 
   /** Run a gloda query to completion, or give up loudly. */
@@ -181,9 +193,12 @@ TBX_MODULE_NAMES.push("gloda");
   }
 
   function isoDate(value) {
-    if (value instanceof Date) {
+    // Duck-typed rather than an instance check: gloda mints its Dates in its own
+    // realm, where such a check is always false, so every hit came back undated —
+    // which also collapsed the date ordering onto subject alone.
+    if (value && typeof value.getTime === "function") {
       const ms = value.getTime();
-      return Number.isFinite(ms) ? value.toISOString() : null;
+      return Number.isFinite(ms) ? new Date(ms).toISOString() : null;
     }
     // Gloda stores PRTime (microseconds) and normally hands back a Date, but
     // conversation bounds have been seen raw.
@@ -284,7 +299,7 @@ TBX_MODULE_NAMES.push("gloda");
       MAX_HITS
     );
     const offset = Number.isInteger(params.offset) && params.offset > 0 ? params.offset : 0;
-    const folderUri = params.folderId ? folderRefToUri(params.folderId) : null;
+    const inFolder = params.folderId ? folderMatcher(params.folderId) : null;
     const Searcher = needMod("GlodaMsgSearcher");
 
     const searcher = new Searcher(null, query, params.matchAll !== false);
@@ -304,7 +319,7 @@ TBX_MODULE_NAMES.push("gloda");
     /* Gloda has no OFFSET, and a folder filter can only be applied after the
      * fact because the searcher's SQL is fixed. Over-fetch, then slice. */
     const retrieve = Math.min(
-      Math.max((offset + limit) * (folderUri ? 10 : 3), 50),
+      Math.max((offset + limit) * (inFolder ? 10 : 3), 50),
       MAX_RETRIEVE
     );
     const messages = await collect(
@@ -324,8 +339,8 @@ TBX_MODULE_NAMES.push("gloda");
     // searcher.scores accumulates in the order items were handed to us.
     const scores = searcher.scores || [];
     let hits = messages.map((message, index) => hit(message, scores[index]));
-    if (folderUri) {
-      hits = hits.filter((entry) => entry.folderUri === folderUri);
+    if (inFolder) {
+      hits = hits.filter(inFolder);
     }
     hits.sort((a, b) => (b.score || 0) - (a.score || 0) || byDateThenSubject(b, a));
 
@@ -519,4 +534,9 @@ TBX_MODULE_NAMES.push("gloda");
     }
     return stats;
   };
+
+  /* Pure helpers, published for the add-on's tests; see the note in core.js. */
+  if (typeof TBX_TEST_HOOKS !== "undefined") {
+    TBX_TEST_HOOKS.gloda = { isoDate, folderMatcher };
+  }
 }

--- a/addon/experiment/modules/gloda.js
+++ b/addon/experiment/modules/gloda.js
@@ -220,6 +220,36 @@ TBX_MODULE_NAMES.push("gloda");
     }
   }
 
+  /** The identities a message involves, or the addresses we do have.
+   *
+   *  Reading an attribute gloda did not index for this message throws, so the
+   *  whole walk is guarded rather than each access. */
+  function involved(message) {
+    try {
+      if (message.involves && message.involves.length) {
+        return [...message.involves];
+      }
+      return [message.from, ...(message.to || [])];
+    } catch (ex) {
+      return [];
+    }
+  }
+
+  /** Everyone in a thread, in the order they first appear — which reads as the
+   *  order they joined the discussion. */
+  function participants(messages) {
+    const labels = [];
+    for (const message of messages) {
+      for (const identity of involved(message)) {
+        const label = identityLabel(identity);
+        if (label && !labels.includes(label)) {
+          labels.push(label);
+        }
+      }
+    }
+    return labels;
+  }
+
   function snippet(message) {
     let text = null;
     try {
@@ -479,6 +509,7 @@ TBX_MODULE_NAMES.push("gloda");
     return {
       conversationId: conversation.id,
       subject: conversation.subject,
+      participants: participants(messages),
       oldestDate: isoDate(conversation.oldestMessageDate),
       newestDate: isoDate(conversation.newestMessageDate),
       messages: ordered.slice(0, limit),

--- a/addon/experiment/modules/gloda.js
+++ b/addon/experiment/modules/gloda.js
@@ -235,8 +235,8 @@ TBX_MODULE_NAMES.push("gloda");
     }
   }
 
-  /** Everyone in a thread, in the order they first appear — which reads as the
-   *  order they joined the discussion. */
+  /** Everyone in a thread, in the order the index handed the messages over,
+   *  each named once. */
   function participants(messages) {
     const labels = [];
     for (const message of messages) {

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Thunderbird MCP Bridge",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Lets a local MCP server drive this Thunderbird: mail, folders, contacts, calendar, filters and settings.",
   "author": "thunderbird-mcp",
   "browser_specific_settings": {

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -46,7 +46,6 @@
     "messagesTags",
     "messagesTagsList",
     "messages.save",
-    "messages.tags",
     "messengerSettings",
     "sessions",
     "tabs",

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -43,7 +43,7 @@ The honest cost of this choice: the connection lives in the add-on's background 
 so its lifetime and reconnect behaviour are now ours to manage. A server *inside*
 Thunderbird would simply be listening whenever Thunderbird is up. In practice the page
 is persistent on 153 and stays connected, but reattaching after the daemon dies
-abnormally is still slower than it should be — measured, and left open, in
+abnormally is still slower than it should be — measured in
 [`VERIFIED-FINDINGS.md`](VERIFIED-FINDINGS.md).
 
 Benefits over an in-Thunderbird HTTP server:
@@ -106,6 +106,24 @@ src/tbmcp/
 docs/
 tests/
 ```
+
+## Testing
+
+Three layers, because no single one can see the whole chain:
+
+- **pytest** (`tests/`) runs the Python side end to end through an in-memory MCP
+  client, with the bridge replaced by a recorder (`tests/conftest.py`). It proves
+  argument validation, gating, the shape of every result and the daemon's own
+  protocol, and needs no Thunderbird — which is also its limit: it cannot see the
+  add-on, and every 1.2.0 search defect lived there.
+- **node** (`tests/js`, `node --test "tests/js/*.test.mjs"`) runs the add-on's
+  real background and privileged scripts under `node:vm` against fakes of the
+  WebExtension and XPCOM surfaces (`tests/js/harness.mjs`). The privileged half is
+  spliced exactly as `build_xpi.py` splices it, so the sandbox rules — no DOM
+  timers, a separate realm, errors that must be `ExtensionError`s — are exercised.
+- **live** (`tools/smoke_live.py`, `tools/smoke_search.py`) drives a running
+  Thunderbird read-only and is the only layer that sees Thunderbird's actual
+  behaviour. It is not in CI; run it before a release.
 
 ## Wire protocol
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -6,8 +6,9 @@ Thunderbird has no external API. Anything that wants to drive it must run *insid
 Thunderbird. The only questions are how privileged that inside code can be, and how
 it talks to the outside.
 
-Every claim below was verified against a live **Thunderbird 153.0** (Windows 11,
-build `20260717002111`), not inferred from documentation. See
+Every claim below was verified against a live Thunderbird — **153.0** (Windows 11,
+build `20260717002111`) when first written, **155.0** for 1.3.0 — not inferred from
+documentation. See
 [`docs/VERIFIED-FINDINGS.md`](VERIFIED-FINDINGS.md) for the raw probe output.
 
 ### The privilege question
@@ -42,9 +43,10 @@ and `fetch("http://127.0.0.1:PORT/...")`. The default MV2 CSP does not restrict
 The honest cost of this choice: the connection lives in the add-on's background page,
 so its lifetime and reconnect behaviour are now ours to manage. A server *inside*
 Thunderbird would simply be listening whenever Thunderbird is up. In practice the page
-is persistent on 153 and stays connected, but reattaching after the daemon dies
-abnormally is still slower than it should be — measured in
-[`VERIFIED-FINDINGS.md`](VERIFIED-FINDINGS.md).
+is persistent on 153–155 and stays connected. Reattaching after the daemon dies
+abnormally used to be slow — measured in
+[`VERIFIED-FINDINGS.md`](VERIFIED-FINDINGS.md); since 1.3.0 the add-on's transport
+watchdogs reconnect within seconds, and the daemon records every attempt.
 
 Benefits over an in-Thunderbird HTTP server:
 

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -62,6 +62,23 @@ model should fix the call), `unsupported` (this Thunderbird build cannot do it),
 `blocked` (a safety rule refused; `error.needs` lists what would unblock it), or
 `internal`.
 
+Inside the add-on, an error crossing from the privileged half to the background page
+travels as an `ExtensionError` whose message is `tbxerr:` followed by that same JSON
+object (`kind`, `message`, `code`, `needs`): Thunderbird keeps the message of an
+`ExtensionError` and discards the rest, so the message is the only channel. The
+background page unpacks it (`tbxError.fromWire`) before the frame above is built;
+nothing tagged `tbxerr:` ever reaches the daemon.
+
+#### Cursors
+
+`messages.query` and `messages.list` return a `cursor` when more remains. It is
+either a raw Thunderbird message-list id (the page boundary coincided with `limit`)
+or `tbx:<load>:<n>`, minted by the add-on when `limit` stopped mid-page: the unread
+remainder of that page is parked behind it, and at most 32 such tails are kept —
+the oldest is evicted and its underlying list aborted. Resuming a cursor from an
+earlier page load, or an evicted one, is a `usage` error rather than a different
+page.
+
 ### `progress` — add-on → daemon, optional, repeatable
 
 ```json

--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -22,8 +22,19 @@ Every frame has a `t` (type) discriminator.
 }
 ```
 
-The daemon replies `{"t":"welcome","sessionId":"...","serverVersion":"..."}` or closes
-with code 4001 (`bad token`) / 4002 (`protocol mismatch`).
+The daemon replies `{"t":"welcome","protocol":1,"server":"tbmcp"}` or closes the
+socket. Close codes, from either side:
+
+| Code | Sent by | Meaning |
+|---|---|---|
+| 1012 | daemon | superseded — a newer add-on connection replaced this one |
+| 4000 | add-on | watchdog — no `welcome` within 8 s of `hello`, or the socket never left CONNECTING within 15 s |
+| 4001 | daemon | bad token — the pairing file the add-on read is stale |
+| 4002 | daemon | no `hello` within 10 s, a malformed `hello`, or a protocol mismatch |
+| 4003 | daemon | non-loopback peer |
+
+The daemon records the outcome of every add-on connection attempt; `tb_status`,
+`tb_diagnostics` and `tbmcp doctor` report the recent failures and what they mean.
 
 ### `req` — daemon → add-on
 

--- a/docs/TOOL-REFERENCE.md
+++ b/docs/TOOL-REFERENCE.md
@@ -392,6 +392,13 @@ conversation id you can pass to `search_conversation`. For precise filters
 If this returns nothing unexpectedly, call `search_index_status`: the global
 indexer can be disabled or still catching up.
 
+`matched` is how many of the retrieved messages matched, and it is the
+total only when `truncated` is absent; a truncated search ranked as deep
+as it could and there may be more below. `unmatchableTerms` names words
+the index cannot look up at all — anything that breaks into pieces of
+fewer than three characters, like "2.0" — and because every term has to
+match, one of those is enough to empty the result.
+
 Parameters: **query**, limit, offset, folder_id  
 *(bold means required; `confirm` is the confirmation gate)*
 

--- a/docs/TOOL-REFERENCE.md
+++ b/docs/TOOL-REFERENCE.md
@@ -18,7 +18,9 @@ Search the user's mail. Combine `full_text` with any filters below.
 `full_text` uses Thunderbird's global index and searches headers and bodies
 of already-indexed messages; `subject`/`author`/`body` are substring matches
 evaluated per folder. Dates are ISO-8601. Results are summaries — call
-`mail_get` for a body. Continue with `cursor=nextCursor`.
+`mail_get` for a body. Continue with `cursor=nextCursor`. A first page
+carries `scope` — the folder and account ids the query covered — so an empty
+result can be read against what was actually searched.
 
 Parameters: full_text, subject, author, recipients, body, folder_id, account_id, include_subfolders, unread, flagged, junk, has_attachment, tags, tag_mode, from_date, to_date, to_me, from_me, min_size, max_size, limit, cursor  
 *(bold means required; `confirm` is the confirmation gate)*
@@ -1213,6 +1215,9 @@ Recent lines from Thunderbird's error console, newest last.
 Narrow it with `contains` — `tbmcp` shows this bridge's own complaints, and an
 add-on id or a source filename shows someone else's. Anything shaped like a
 password or token is redacted inside Thunderbird before it is sent.
+
+Lines the bridge writes with `console.*` (`source: "console"`) are included
+alongside the error console's own entries, merged by time.
 
 Parameters: contains, limit  
 *(bold means required; `confirm` is the confirmation gate)*

--- a/docs/superpowers/plans/2026-09-08-v1.3.md
+++ b/docs/superpowers/plans/2026-09-08-v1.3.md
@@ -1,0 +1,17 @@
+# v1.3.0 — implementation record
+
+Spec: [2026-09-08-v1.3-search-and-bridge-design.md](../specs/2026-09-08-v1.3-search-and-bridge-design.md).
+Branch `feat/v1.3.0` from `main` at 3241b2f. Each task was implemented test-first,
+reviewed against its brief, and fixed until the review was clean.
+
+| # | Task | Commits |
+|---|---|---|
+| 1 | JS test harness (`tests/js/harness.mjs`) and transport hardening: synchronous hello, handshake/connect/pairing watchdogs, re-entrancy guard, backoff, visible state, `transport` section in the status file, manifest permission cleanup | 09c9bb3..2b3e720 |
+| 2 | `messages.query` page semantics, `scope`, paging that keeps the remainder (`tbx:<load>:<n>` cursors) | 614f86f..086d9ec |
+| 3 | Privileged half: platform timers, `tbxerr:` envelope across the whole API, duck-typed dates, folder matching, unmatchable terms, exact `truncated`, participants; Python field contract | fe7bc6b..b61e52a |
+| 4 | Error fidelity: daemon relay, `ToolError`, stream limit, typed `TOO_LARGE`, read-loop invalidation | 622eeaf..a0b1e2f |
+| 5 | Handshake telemetry, `tb_status`/`doctor` diagnostics, daemon log, safe stand-down, add-on console visibility, `install-addon` robustness | 4c3d386..04e2c39 |
+| 6 | `smoke_search.py`, CI (node tests, Python 3.14), version 1.3.0, CHANGELOG, README and docs | 686da76.. |
+
+Live checks on Thunderbird 155 were run after tasks 1, 3, 4 and 5 by installing
+the branch's add-on build; the final run is recorded in the release notes.

--- a/docs/superpowers/specs/2026-09-08-v1.3-search-and-bridge-design.md
+++ b/docs/superpowers/specs/2026-09-08-v1.3-search-and-bridge-design.md
@@ -1,0 +1,120 @@
+# Working search, and a bridge that says what is wrong (v1.3)
+
+Status: implemented 2026-09-08
+
+## Problem
+
+Issue #3 reported that every search tool in 1.2.0 was broken, from six independent
+defects in this repository — none of them Thunderbird API drift. Reproduced here on
+Thunderbird 155 with the 1.2.0 add-on before any change:
+
+| Call | 1.2.0 |
+|---|---|
+| `mail_search(subject="Re")` on a 195-message inbox | 0 items, `searchedFolders: null` |
+| `search_global`, `search_conversation` | `An unexpected error occurred [Error] [Error]` |
+| `search_index_status` | `indexedMessages: null` |
+| `mail_list(limit=3)` then its cursor | ids 202,201,200 then 109,108,107 — 97 skipped |
+
+Two further failures surfaced while diagnosing:
+
+1. The add-on can wedge. After its daemon went away, a long-running add-on session
+   kept opening TCP connections that never completed the WebSocket upgrade, every
+   ~25 s, for over thirty minutes. `tb_status` said "ask the user to start
+   Thunderbird" and `doctor` said "try again in a moment". Nothing named the state.
+2. The test suite could not see any of it: 195 tests passed on the broken code
+   because the bridge is replaced by a recorder and the add-on is never exercised.
+
+## Goals
+
+- Every search tool works, with fields the Python side actually receives.
+- Paging never loses a message.
+- A deliberate error message reaches the model, on every `mcp` version we support.
+- A bridge that is failing says so, with the remedy, from `tb_status` and `doctor`.
+- A test layer that can see the add-on, run in CI.
+- Verified against Thunderbird 155; Python 3.11–3.14.
+
+## Non-goals
+
+- Publishing to PyPI.
+- Any change to the wire protocol between daemon and add-on (`PROTOCOL = 1`).
+- Adopting the fixes proposed in the contributor's pull requests; this release is an
+  independent implementation.
+
+## Design
+
+### Search (`addon/experiment/**`, `addon/background/handlers/messages.js`)
+
+- `messages.query` no longer asks for `returnMessageListId`; it asks for a page
+  sized to `limit` and walks pages. A first page carries `scope`.
+- The privileged half imports `setTimeout`/`clearTimeout` from `Timer.sys.mjs`;
+  `H.withTimeout` clears its timer when the race settles.
+- `isoDate` duck-types (`getTime`), rebuilding the ISO string in this realm.
+- A folder reference is matched against a hit's own `folderId` (known account key)
+  or `folderUri` (known server root); anything else is a usage error naming it.
+- `classifyTerms` splits every term the way the indexer does and reports the ones
+  that cannot match in `unmatchableTerms` and in the empty-result note.
+- The searcher asks for one row more than it will use, so `truncated` is exact.
+- `gloda.conversation` returns `participants` (ordered, unique, from `involves`).
+
+### Errors that survive every hop
+
+- Every method of the privileged `tbx` API is wrapped once (`wired()`): a failure is
+  rethrown as an `ExtensionError` whose message is `tbxerr:` + JSON
+  `{kind, message, code, needs}`; `tbxError.fromWire` unpacks it in the background
+  page. A bare `Error` name is no longer reported as a code.
+- The daemon relays `exc.message`, not `str(exc)`, so rendering happens once.
+- `Registrar._add` re-raises `TbmcpError` as the SDK's `ToolError`; `mcp` 2.0 and 2.2
+  both pass it through.
+- Both control streams open with `limit=ipc.MAX_LINE`; an oversized frame is a typed
+  `TOO_LARGE`; a stopped read loop closes its writer so the next call reconnects.
+
+### Paging
+
+`collectPage` parks the unread tail of a page against a cursor of the form
+`tbx:<load>:<n>` (bounded to 32 parked pages, oldest evicted and its Thunderbird
+list aborted). A raw Thunderbird list id is returned only when nothing was left
+over. A cursor from another page load, or an evicted one, is refused with a usage
+error rather than resolving to a different page.
+
+### The bridge, from both sides
+
+- Add-on (`transport.js`): the hello is sent synchronously from `onopen`; a socket
+  without a `welcome` within 8 s or still connecting after 15 s is closed (4000) and
+  counted as a failure; the pairing read has a 5 s deadline of its own; `connect()`
+  is re-entrancy guarded; an unchanged pairing backs off rather than polls; every
+  close is logged with its code; the state is written into
+  `tbmcp-addon-status.json` as `transport`.
+- Daemon (`handshake.py`, `daemon.py`): every TCP connection to the add-on port is
+  recorded from accept to close — `no-upgrade`, `no-hello-timeout`,
+  `closed-before-hello`, `bad-hello`, `bad-token`, `protocol-mismatch`,
+  `welcomed`, `superseded`, `disconnected` — via `websockets`' `create_connection`
+  and `process_request` hooks (present in 15 and 16). `daemon.status` carries the
+  summary; a "not connected" error carries the diagnosis.
+- Reporting: `tb_status`/`tb_diagnostics` replace the fixed hint with the diagnosis
+  when there are recent failures; `doctor` prints installed vs source add-on
+  version, the handshake summary, the add-on's transport state and the daemon log
+  path, and orders its remedies. The daemon logs to `<state dir>/tbmcp/daemon.log`.
+- A superseded daemon leaves the winner's files alone; `install-addon` restarts
+  Thunderbird on every exit path.
+
+### Testing
+
+`tests/js` runs the real add-on scripts under `node:vm` with fakes for the
+WebExtension API, XPCOM services, timers and WebSockets; the privileged half is
+spliced exactly as the build does it. `tools/smoke_search.py` is the live
+acceptance run. CI runs pytest, the node tests, consistency, build and docs on
+three platforms and Python 3.11/3.13/3.14.
+
+## Verification
+
+- pytest 286, node 111, ruff, `check_consistency.py`, `build_xpi.py`, docs in sync.
+- Live on Thunderbird 155 with the 1.3.0 add-on: every row of the table above passes;
+  a 200-hit search arrives (122 hits) and the bridge stays up; a replaced daemon is
+  re-attached by the add-on in 3 s.
+
+## Risks
+
+- The 5 s/8 s/15 s deadlines are chosen, not measured; a slow privileged half is
+  given up on (safely — the fallbacks are empty capabilities, not a dead bridge).
+- `websockets`' `create_connection`/`process_request` are public but described as
+  advanced; pinned `>=15,<17` and verified on both.

--- a/docs/superpowers/specs/2026-09-08-v1.3-search-and-bridge-design.md
+++ b/docs/superpowers/specs/2026-09-08-v1.3-search-and-bridge-design.md
@@ -37,8 +37,8 @@ Two further failures surfaced while diagnosing:
 
 - Publishing to PyPI.
 - Any change to the wire protocol between daemon and add-on (`PROTOCOL = 1`).
-- Adopting the fixes proposed in the contributor's pull requests; this release is an
-  independent implementation.
+- Reusing the fixes proposed alongside the report; this release is an independent
+  implementation with its own tests.
 
 ## Design
 
@@ -107,10 +107,11 @@ three platforms and Python 3.11/3.13/3.14.
 
 ## Verification
 
-- pytest 286, node 111, ruff, `check_consistency.py`, `build_xpi.py`, docs in sync.
-- Live on Thunderbird 155 with the 1.3.0 add-on: every row of the table above passes;
-  a 200-hit search arrives (122 hits) and the bridge stays up; a replaced daemon is
-  re-attached by the add-on in 3 s.
+- pytest 287, node 111, ruff, `check_consistency.py`, `build_xpi.py`, docs in sync.
+- Live on Thunderbird 155.0 with the 1.3.0 add-on installed: `tools/smoke_search.py`
+  13/13 and `tools/smoke_live.py` 17/17 — every row of the table above passes, a
+  154-hit search arrives with the bridge still up, and a replaced daemon was
+  re-attached by the add-on in 3 s (measured during development on the same day).
 
 ## Risks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "thunderbird-mcp"
-version = "1.2.1"
+version = "1.3.0"
 description = "MCP server that drives Thunderbird — mail, folders, contacts, calendar, filters, and settings"
 readme = "README.md"
 requires-python = ">=3.11"
@@ -18,6 +18,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Topic :: Communications :: Email",
 ]
 dependencies = [

--- a/src/tbmcp/addon_install.py
+++ b/src/tbmcp/addon_install.py
@@ -258,7 +258,9 @@ def install_automatic(
     # client closed. That happened: the add-on was installed and attached, the
     # install script's reply was lost, and Thunderbird stayed down.
     try:
-        return _install_over_marionette(exe, profile, package, identifier)
+        return _install_over_marionette(
+            exe, profile, package, identifier, restart_after=restart_after
+        )
     finally:
         _restart_plain(exe, profile, restart_after)
 
@@ -268,6 +270,8 @@ def _install_over_marionette(
     profile: ThunderbirdProfile | None,
     package: pathlib.Path,
     identifier: str,
+    *,
+    restart_after: bool,
 ) -> InstallOutcome:
     """Drive the install through Marionette; the caller owns the restart."""
     if not marionette.wait_for_port(timeout=90.0):
@@ -284,7 +288,7 @@ def _install_over_marionette(
         if not isinstance(report, dict):
             # A lost reply is not a failed install: the script may well have run to
             # completion. Ask the AddonManager before deciding.
-            report = _report_from_status(client, identifier, report)
+            report = _report_from_status(client, identifier, report, restarting=restart_after)
     finally:
         # Always take Marionette back down: while it is listening, any local process
         # can run privileged code inside Thunderbird.
@@ -307,7 +311,9 @@ def _install_over_marionette(
     )
 
 
-def _report_from_status(client: marionette.Marionette, identifier: str, raw: object) -> dict:
+def _report_from_status(
+    client: marionette.Marionette, identifier: str, raw: object, *, restarting: bool
+) -> dict:
     """Rebuild an install report from the AddonManager when the script's reply was lost."""
     expected = addon_version()
     status = client.execute(STATUS_SCRIPT, [identifier], timeout_ms=20_000)
@@ -328,7 +334,12 @@ def _report_from_status(client: marionette.Marionette, identifier: str, raw: obj
     raise TbmcpError(
         f"unexpected response from Thunderbird: {raw!r}, and the AddonManager does not "
         f"report {identifier} {expected} as installed and active ({status!r}). "
-        "Thunderbird has been restarted; try again, or use `tbmcp install-addon --manual`.",
+        + (
+            "Thunderbird is being restarted; "
+            if restarting
+            else "Thunderbird was left stopped (--no-restart); "
+        )
+        + "try again, or use `tbmcp install-addon --manual`.",
         code="INSTALL_UNVERIFIED",
     )
 

--- a/src/tbmcp/addon_install.py
+++ b/src/tbmcp/addon_install.py
@@ -252,6 +252,24 @@ def install_automatic(
 
     log.info("starting Thunderbird with automation enabled")
     _launch(exe, ["-marionette", "-remote-allow-system-access"], profile)
+    # From here on Thunderbird is ours to put back. Every exit — a Marionette that
+    # never opens, a script that answers nothing, an exception mid-way — goes
+    # through the same restart, so the command can fail without leaving the mail
+    # client closed. That happened: the add-on was installed and attached, the
+    # install script's reply was lost, and Thunderbird stayed down.
+    try:
+        return _install_over_marionette(exe, profile, package, identifier)
+    finally:
+        _restart_plain(exe, profile, restart_after)
+
+
+def _install_over_marionette(
+    exe: pathlib.Path,
+    profile: ThunderbirdProfile | None,
+    package: pathlib.Path,
+    identifier: str,
+) -> InstallOutcome:
+    """Drive the install through Marionette; the caller owns the restart."""
     if not marionette.wait_for_port(timeout=90.0):
         raise TbmcpError(
             "Thunderbird started but never opened the Marionette port. Try "
@@ -263,31 +281,55 @@ def install_automatic(
     try:
         client.start_chrome_session()
         report = client.execute(INSTALL_SCRIPT, [str(package), identifier], timeout_ms=120_000)
+        if not isinstance(report, dict):
+            # A lost reply is not a failed install: the script may well have run to
+            # completion. Ask the AddonManager before deciding.
+            report = _report_from_status(client, identifier, report)
     finally:
         # Always take Marionette back down: while it is listening, any local process
         # can run privileged code inside Thunderbird.
         client.quit_application()
 
-    if not isinstance(report, dict):
-        raise TbmcpError(f"unexpected response from Thunderbird: {report!r}")
     if report.get("error"):
-        message = str(report["error"])
-        _restart_plain(exe, profile, restart_after)
-        return InstallOutcome(False, message, package, report)
+        return InstallOutcome(False, str(report["error"]), package, report)
 
     result = report.get("result") or {}
     if not result.get("ok"):
-        _restart_plain(exe, profile, restart_after)
         return InstallOutcome(False, str(result.get("error") or "install failed"), package, report)
 
     _stop()
-    _restart_plain(exe, profile, restart_after)
     return InstallOutcome(
         True,
         f"installed {identifier} {result.get('version')} "
         f"(unsigned, active={result.get('isActive')})",
         package,
         report,
+    )
+
+
+def _report_from_status(client: marionette.Marionette, identifier: str, raw: object) -> dict:
+    """Rebuild an install report from the AddonManager when the script's reply was lost."""
+    expected = addon_version()
+    status = client.execute(STATUS_SCRIPT, [identifier], timeout_ms=20_000)
+    if (
+        isinstance(status, dict)
+        and status.get("installed")
+        and status.get("isActive")
+        and str(status.get("version")) == expected
+    ):
+        log.warning(
+            "the install script's reply was lost (%r), but Thunderbird reports %s %s "
+            "installed and active — treating that as success",
+            raw,
+            identifier,
+            expected,
+        )
+        return {"result": {"ok": True, "version": expected, "isActive": True}, "recovered": True}
+    raise TbmcpError(
+        f"unexpected response from Thunderbird: {raw!r}, and the AddonManager does not "
+        f"report {identifier} {expected} as installed and active ({status!r}). "
+        "Thunderbird has been restarted; try again, or use `tbmcp install-addon --manual`.",
+        code="INSTALL_UNVERIFIED",
     )
 
 

--- a/src/tbmcp/bootstrap.py
+++ b/src/tbmcp/bootstrap.py
@@ -346,7 +346,7 @@ def choose_interpreter(
     )
 
 
-VERSION = "1.2.0"
+VERSION = "1.3.0"
 GIT_SOURCE = "git+https://github.com/U-C4N/Thunderbird-MCP"
 
 

--- a/src/tbmcp/bridge.py
+++ b/src/tbmcp/bridge.py
@@ -113,7 +113,7 @@ class Bridge:
             if info is None:
                 raise TransportError("the daemon vanished right after starting", code="NO_DAEMON")
 
-        reader, writer = await asyncio.open_connection("127.0.0.1", info.port)
+        reader, writer = await asyncio.open_connection("127.0.0.1", info.port, limit=ipc.MAX_LINE)
         self._next_id += 1
         await ipc.write_message(writer, {"t": "auth", "id": self._next_id, "token": info.token})
         reply = await asyncio.wait_for(ipc.read_message(reader), timeout=10.0)

--- a/src/tbmcp/bridge.py
+++ b/src/tbmcp/bridge.py
@@ -151,6 +151,7 @@ class Bridge:
 
     async def _read_loop(self) -> None:
         assert self._reader is not None
+        reason, code = "the daemon connection dropped", "DISCONNECTED"
         try:
             while True:
                 message = await ipc.read_message(self._reader)
@@ -179,14 +180,22 @@ class Bridge:
                     )
         except (TransportError, OSError) as exc:
             log.debug("control read loop ended: %s", exc)
+            if isinstance(exc, TransportError) and exc.code:
+                # A frame we could not read is not a daemon that hung up, and the
+                # caller can only tell the two apart if the code survives the handover.
+                reason, code = exc.message, exc.code
         finally:
             for future in self._pending.values():
                 if not future.done():
-                    future.set_exception(
-                        TransportError("the daemon connection dropped", code="DISCONNECTED")
-                    )
+                    future.set_exception(TransportError(reason, code=code))
             self._pending.clear()
             self._progress.clear()
+            if self._writer is not None:
+                # `_ensure` judges the connection by the writer alone, so a writer left
+                # open once the reader has stopped means the next call writes into a
+                # socket nobody reads and then waits out its whole timeout. Only the
+                # close belongs here: `_teardown` awaits this very task.
+                self._writer.close()
 
     # ------------------------------------------------------------------ public API
 

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -22,15 +22,44 @@ from collections.abc import Sequence
 from .config import ALL_TOOLSETS, Settings, parse_toolsets
 from .handshake import describe_handshake
 
+LOG_FORMAT = "%(asctime)s %(levelname)-7s %(name)s: %(message)s"
+
 
 def _configure_logging(verbose: bool) -> None:
     logging.basicConfig(
         level=logging.DEBUG if verbose else logging.INFO,
         stream=sys.stderr,
-        format="%(asctime)s %(levelname)-7s %(name)s: %(message)s",
+        format=LOG_FORMAT,
     )
     # websockets logs every frame at DEBUG; that is never what we want.
     logging.getLogger("websockets").setLevel(logging.WARNING)
+
+
+def _attach_log_file(path) -> None:
+    """Also write the log to `path`, so the daemon's side of a failure survives.
+
+    The daemon is spawned detached with all three streams on DEVNULL, which meant
+    everything it logged — a handshake that never completed, a stand-down, the
+    reason it exited — was discarded as it was written, and the only account of a
+    broken bridge was whatever the add-on managed to leave in the profile.
+
+    Called after `_configure_logging`, which sets the root level: a handler added
+    first would also stop `basicConfig` configuring stderr at all.
+    """
+    from logging.handlers import RotatingFileHandler
+
+    from . import ipc
+
+    try:
+        handler = RotatingFileHandler(path, maxBytes=512_000, backupCount=2, encoding="utf-8")
+    except OSError as exc:
+        # A log we cannot open is not a reason to refuse to run.
+        logging.getLogger("tbmcp").warning("cannot write the daemon log %s: %s", path, exc)
+        return
+    handler.setLevel(logging.INFO)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    logging.getLogger().addHandler(handler)
+    ipc._restrict_permissions(path)
 
 
 def _settings_from_args(args: argparse.Namespace) -> Settings:
@@ -69,7 +98,9 @@ def cmd_serve(args: argparse.Namespace) -> int:
 
 def cmd_daemon(args: argparse.Namespace) -> int:
     from .daemon import run_daemon
+    from .ipc import daemon_log_path
 
+    _attach_log_file(daemon_log_path())
     return asyncio.run(run_daemon(args.profile, idle_timeout=args.idle_timeout, force=args.force))
 
 

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -15,9 +15,12 @@ import json
 import logging
 import os
 import sys
+import textwrap
+import time
 from collections.abc import Sequence
 
 from .config import ALL_TOOLSETS, Settings, parse_toolsets
+from .handshake import describe_handshake
 
 
 def _configure_logging(verbose: bool) -> None:
@@ -124,10 +127,34 @@ def _doctor_ok(report: dict) -> bool:
     return bridge_ok and tool_ok
 
 
+def _addon_version_check(report: dict) -> dict:
+    """The add-on Thunderbird is running, against the one this package ships.
+
+    Three sources: what the live session announced, what the add-on wrote into the
+    profile at startup, and the manifest in this source tree. A connected older
+    add-on is still a working chain — `_doctor_ok` deliberately ignores this — but
+    it is the first thing to fix when anything else is wrong, because every other
+    remedy assumes the two halves came out of the same package.
+    """
+    status = report.get("addonStatus")
+    installed = None
+    if isinstance(status, dict) and not status.get("error"):
+        installed = status.get("addonVersion")
+    live = ((report.get("bridge") or {}).get("thunderbird") or {}).get("addonVersion")
+    source = (report.get("addon") or {}).get("addonVersion")
+    running = live or installed
+    return {
+        "installed": installed,
+        "live": live,
+        "source": source,
+        "mismatch": bool(source and running and running != source),
+    }
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     from . import addon_install
     from .bridge import Bridge, set_shared_bridge
-    from .ipc import DaemonInfo
+    from .ipc import DaemonInfo, daemon_log_path
     from .profile import ProfileSnapshot, find_profile, list_profiles
     from .server import build_server
 
@@ -163,6 +190,9 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     report["daemon"] = (
         {"running": True, "pid": info.pid, "port": info.port} if info else {"running": False}
     )
+    # The daemon is spawned detached onto DEVNULL, so this file is the only place
+    # its side of a failure survives.
+    report["daemon"]["logFile"] = str(daemon_log_path())
 
     async def probe() -> None:
         bridge = Bridge(profile_hint=settings.profile, autostart=not args.no_start)
@@ -204,6 +234,14 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     asyncio.run(probe())
 
+    # Both derived from what is already in the report, once the probe has filled in
+    # the live half: which add-on is actually running, and the add-on's own account
+    # of its connection attempts.
+    report["addonVersions"] = _addon_version_check(report)
+    status_report = report.get("addonStatus")
+    if isinstance(status_report, dict) and isinstance(status_report.get("transport"), dict):
+        report["addonTransport"] = status_report["transport"]
+
     report["toolsets"] = {
         "selected": list(settings.toolsets),
         "available": list(ALL_TOOLSETS),
@@ -222,9 +260,46 @@ def cmd_doctor(args: argparse.Namespace) -> int:
     return 0 if ok else 1
 
 
+def _handshake_line(summary: dict | None) -> str:
+    """The Bridge section's account of what the add-on's connections did.
+
+    "Nothing has dialled in" and "it has dialled in three times and failed every
+    time" are opposite problems that used to print identically.
+    """
+    attempts = int((summary or {}).get("attempts") or 0)
+    if not summary or not attempts:
+        return "none since the daemon started"
+    parts = [f"{attempts} attempt{'' if attempts == 1 else 's'}"]
+    outcome = summary.get("lastOutcome")
+    if outcome:
+        at = summary.get("lastAttemptAt")
+        ago = f" {time.time() - at:.0f} s ago" if isinstance(at, int | float) else ""
+        parts.append(f"last {outcome}{ago}")
+    agent = summary.get("lastUserAgent")
+    return "; ".join(parts) + (f" ({agent})" if agent else "")
+
+
+def _transport_line(transport: dict) -> str:
+    """The add-on's own side of the same story, from the file it writes at startup."""
+    parts = [str(transport.get("state") or "unknown")]
+    failures = transport.get("consecutiveFailures")
+    if failures is not None:
+        parts.append(f"{failures} failed attempt{'' if failures == 1 else 's'}")
+    if transport.get("lastCloseCode") is not None:
+        parts.append(f"last close {transport['lastCloseCode']} at {transport.get('lastCloseAt')}")
+    return "; ".join(parts)
+
+
 def _print_doctor(report: dict) -> None:
     def line(label: str, value: object) -> None:
         print(f"  {label:<26} {value}")
+
+    def paragraph(text: str) -> None:
+        """One wrapped bullet, for a diagnosis too long to fit on a line."""
+        wrapped = textwrap.wrap(text, 76) or [text]
+        print(f"  * {wrapped[0]}")
+        for extra in wrapped[1:]:
+            print(f"    {extra}")
 
     print("thunderbird-mcp doctor\n")
     print("Python")
@@ -236,6 +311,8 @@ def _print_doctor(report: dict) -> None:
     line("executable", addon.get("thunderbirdExe") or "NOT FOUND")
     line("running", addon.get("thunderbirdRunning"))
     line("add-on version (source)", addon.get("addonVersion"))
+    versions = report.get("addonVersions") or {}
+    line("add-on version (installed)", versions.get("installed") or "unknown")
     line("profile", report.get("profileSelected") or "NOT FOUND")
     if report.get("accountsOnDisk") is not None:
         line("accounts (from prefs.js)", report["accountsOnDisk"])
@@ -257,6 +334,7 @@ def _print_doctor(report: dict) -> None:
     print("\nBridge")
     daemon = report.get("daemon") or {}
     line("daemon", f"pid {daemon.get('pid')}" if daemon.get("running") else "not running")
+    line("daemon log", daemon.get("logFile") or "unknown")
     bridge = report.get("bridge") or {}
     if bridge.get("error"):
         line("status", f"ERROR: {bridge['error']}")
@@ -268,6 +346,10 @@ def _print_doctor(report: dict) -> None:
             line("privileged half", tb.get("experiment"))
             app = tb.get("app") or {}
             line("app", f"{app.get('name')} {app.get('version')}")
+    line("add-on handshakes", _handshake_line(bridge.get("handshake")))
+    transport = report.get("addonTransport")
+    if transport:
+        line("add-on transport", _transport_line(transport))
 
     tool_call = report.get("tbStatusCall") or {}
     if tool_call.get("skipped"):
@@ -283,20 +365,37 @@ def _print_doctor(report: dict) -> None:
     line("read-only", tools.get("readOnly"))
     line("send mode", tools.get("sendMode"))
 
+    if bridge.get("connected") and versions.get("mismatch"):
+        seen = versions.get("live") or versions.get("installed")
+        print(f"\nWarning: installed add-on is {seen}, source is {versions.get('source')} — run")
+        print("         `tbmcp install-addon` and restart Thunderbird to update it.")
+
     if not bridge.get("connected"):
         print("\nNot connected. In order, check:")
         if not addon.get("thunderbirdRunning"):
             print("  * Thunderbird is not running — start it.")
-        elif report.get("addonStatus") is None:
-            print("  * The add-on never wrote its startup report, so either it is not")
-            print("    installed or its privileged half failed to load.")
-            print("    Install or reinstall it:  tbmcp install-addon")
-        elif not (bridge.get("thunderbird") or {}):
-            print("  * The add-on started but has not dialled in yet. It polls for the")
-            print("    pairing file about once a second; try again in a moment.")
-        elif not (bridge.get("thunderbird") or {}).get("experiment"):
-            print("  * The privileged half did not load; settings tools will fail.")
-            print("    Reinstall:  tbmcp install-addon")
+        else:
+            # A stale add-on is worth saying whatever else is wrong: it is often the
+            # cause, and every remedy below assumes the two halves match.
+            if versions.get("mismatch"):
+                seen = versions.get("live") or versions.get("installed")
+                print(f"  * The installed add-on is {seen}, source is {versions.get('source')}.")
+                print("    Run `tbmcp install-addon` and restart Thunderbird.")
+            failures = describe_handshake(bridge.get("handshake"))
+            if failures:
+                # It has dialled in, repeatedly. Anything below would be a guess that
+                # the record already contradicts.
+                paragraph(failures)
+            elif report.get("addonStatus") is None:
+                print("  * The add-on never wrote its startup report, so either it is not")
+                print("    installed or its privileged half failed to load.")
+                print("    Install or reinstall it:  tbmcp install-addon")
+            elif not (bridge.get("thunderbird") or {}):
+                print("  * The add-on started but has not dialled in yet. It polls for the")
+                print("    pairing file about once a second; try again in a moment.")
+            elif not (bridge.get("thunderbird") or {}).get("experiment"):
+                print("  * The privileged half did not load; settings tools will fail.")
+                print("    Reinstall:  tbmcp install-addon")
 
 
 def cmd_setup(args: argparse.Namespace) -> int:

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -403,15 +403,15 @@ def _print_doctor(report: dict) -> None:
 
     if not bridge.get("connected"):
         print("\nNot connected. In order, check:")
+        # A stale add-on is worth saying whatever else is wrong — including when
+        # Thunderbird is closed, or the user starts it and is back here in a minute.
+        if versions.get("mismatch"):
+            seen = versions.get("live") or versions.get("installed")
+            print(f"  * The installed add-on is {seen}, source is {versions.get('source')}.")
+            print("    Run `tbmcp install-addon` and restart Thunderbird.")
         if not addon.get("thunderbirdRunning"):
             print("  * Thunderbird is not running — start it.")
         else:
-            # A stale add-on is worth saying whatever else is wrong: it is often the
-            # cause, and every remedy below assumes the two halves match.
-            if versions.get("mismatch"):
-                seen = versions.get("live") or versions.get("installed")
-                print(f"  * The installed add-on is {seen}, source is {versions.get('source')}.")
-                print("    Run `tbmcp install-addon` and restart Thunderbird.")
             failures = describe_handshake(bridge.get("handshake"))
             if failures:
                 # It has dialled in, repeatedly. Anything below would be a guess that

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -265,6 +265,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     asyncio.run(probe())
 
+    # The probe may have started the daemon it then connected to, so the
+    # advertisement read above can be stale: on a first run it printed "daemon:
+    # not running" directly above "connected: True". Read it again now.
+    info = DaemonInfo.load()
+    report["daemon"] = (
+        {"running": True, "pid": info.pid, "port": info.port} if info else {"running": False}
+    )
+    report["daemon"]["logFile"] = str(daemon_log_path())
+
     # Both derived from what is already in the report, once the probe has filled in
     # the live half: which add-on is actually running, and the add-on's own account
     # of its connection attempts.

--- a/src/tbmcp/cli.py
+++ b/src/tbmcp/cli.py
@@ -217,13 +217,6 @@ def cmd_doctor(args: argparse.Namespace) -> int:
             report["addonStatus"] = None
 
     report["addon"] = addon_install.summary()
-    info = DaemonInfo.load()
-    report["daemon"] = (
-        {"running": True, "pid": info.pid, "port": info.port} if info else {"running": False}
-    )
-    # The daemon is spawned detached onto DEVNULL, so this file is the only place
-    # its side of a failure survives.
-    report["daemon"]["logFile"] = str(daemon_log_path())
 
     async def probe() -> None:
         bridge = Bridge(profile_hint=settings.profile, autostart=not args.no_start)
@@ -265,13 +258,15 @@ def cmd_doctor(args: argparse.Namespace) -> int:
 
     asyncio.run(probe())
 
-    # The probe may have started the daemon it then connected to, so the
-    # advertisement read above can be stale: on a first run it printed "daemon:
-    # not running" directly above "connected: True". Read it again now.
+    # Read the advertisement only now: the probe may have started the daemon it
+    # then connected to, and reading before it printed "daemon: not running"
+    # directly above "connected: True" on every first run.
     info = DaemonInfo.load()
     report["daemon"] = (
         {"running": True, "pid": info.pid, "port": info.port} if info else {"running": False}
     )
+    # The daemon is spawned detached onto DEVNULL, so this file is the only place
+    # its side of a failure survives.
     report["daemon"]["logFile"] = str(daemon_log_path())
 
     # Both derived from what is already in the report, once the probe has filled in

--- a/src/tbmcp/daemon.py
+++ b/src/tbmcp/daemon.py
@@ -30,6 +30,7 @@ from websockets.exceptions import ConnectionClosed
 
 from . import ipc
 from .errors import NotConnectedError, TimeoutError_, TransportError, from_wire
+from .handshake import HandshakeLog, describe_handshake
 from .profile import BRIDGE_FILE, ThunderbirdProfile, find_profile
 
 log = logging.getLogger("tbmcp.daemon")
@@ -37,6 +38,9 @@ log = logging.getLogger("tbmcp.daemon")
 CHUNK_LIMIT = 4 * 1024 * 1024
 PING_INTERVAL = 20.0
 DEFAULT_IDLE_TIMEOUT = 900.0
+HELLO_TIMEOUT = 10.0
+"""How long a connected add-on has to send its `hello`. A module constant so the
+handshake tests can shorten it without waiting out a real ten seconds."""
 
 ProgressCb = Callable[[dict[str, Any]], Awaitable[None]]
 
@@ -233,6 +237,7 @@ class Daemon:
         self.startup_lock = startup_lock
         self.addon_token = ipc.new_token()
         self.control_token = ipc.new_token()
+        self.handshakes = HandshakeLog()
         self.session: AddonSession | None = None
         self.events: deque[dict[str, Any]] = deque(maxlen=event_buffer)
         self.event_seq = 0
@@ -246,29 +251,58 @@ class Daemon:
     # ------------------------------------------------------------------ add-on side
 
     async def _serve_addon(self, ws: ServerConnection) -> None:
+        """One add-on connection, from the upgrade to whatever ends it.
+
+        Every exit records its own outcome in `self.handshakes`. Splitting what used
+        to be one `except` is the point: "the socket closed before the hello" and
+        "the hello was not JSON" are different faults with different remedies, and
+        collapsing them left the user with nothing but a 4002 close code.
+        """
         peer = ws.remote_address[0] if ws.remote_address else "?"
         if peer not in ("127.0.0.1", "::1", "localhost"):
+            self.handshakes.resolve(ws, "non-loopback", close_code=4003, detail=str(peer))
             await ws.close(code=4003, reason="non-loopback peer")
             return
         try:
-            raw = await asyncio.wait_for(ws.recv(), timeout=10.0)
-            hello = json.loads(raw)
-        except (TimeoutError, ConnectionClosed, json.JSONDecodeError, TypeError):
+            raw = await asyncio.wait_for(ws.recv(), timeout=HELLO_TIMEOUT)
+        except TimeoutError:
+            self.handshakes.resolve(
+                ws, "no-hello-timeout", close_code=4002, detail=f"{HELLO_TIMEOUT:g}s"
+            )
             await ws.close(code=4002, reason="expected a hello frame")
+            return
+        except ConnectionClosed:
+            # Already gone: there is nothing left to close, only to record.
+            self.handshakes.resolve(ws, "closed-before-hello", close_code=ws.close_code)
+            return
+        try:
+            hello = json.loads(raw)
+        except (json.JSONDecodeError, TypeError) as exc:
+            await self._reject_hello(ws, detail=str(exc))
             return
         if not isinstance(hello, dict) or hello.get("t") != "hello":
-            await ws.close(code=4002, reason="expected a hello frame")
+            await self._reject_hello(ws, detail=f"first frame was {type(hello).__name__}")
             return
         if hello.get("token") != self.addon_token:
-            log.warning("rejected an add-on connection with a bad token")
+            self.handshakes.resolve(ws, "bad-token", close_code=4001)
             await ws.close(code=4001, reason="bad token")
             return
-        if int(hello.get("protocol", 0)) != ipc.PROTOCOL_VERSION:
+        try:
+            protocol = int(hello.get("protocol", 0))
+        except (TypeError, ValueError):
+            # A non-numeric version used to raise straight out of the handler, so
+            # websockets logged a traceback and the add-on was told nothing at all.
+            protocol = -1
+        if protocol != ipc.PROTOCOL_VERSION:
+            self.handshakes.resolve(
+                ws, "protocol-mismatch", close_code=4002, detail=f"protocol {protocol}"
+            )
             await ws.close(code=4002, reason="protocol mismatch")
             return
 
         if self.session is not None:
             # A restarted Thunderbird, or a second window; the newest wins.
+            self.handshakes.resolve(self.session.ws, "superseded", close_code=1012)
             with contextlib.suppress(ConnectionClosed):
                 await self.session.ws.close(code=1012, reason="superseded")
 
@@ -278,6 +312,7 @@ class Daemon:
         await ws.send(
             json.dumps({"t": "welcome", "protocol": ipc.PROTOCOL_VERSION, "server": "tbmcp"})
         )
+        self.handshakes.resolve(ws, "welcomed", addon_version=session.addon_version)
         log.info(
             "add-on connected: %s %s (experiment=%s)",
             session.app.get("name", "Thunderbird"),
@@ -294,7 +329,61 @@ class Daemon:
             if self.session is session:
                 self.session = None
                 self._session_ready.clear()
-            log.info("add-on disconnected")
+            # A no-op for a session we superseded: that outcome is already final.
+            self.handshakes.resolve(ws, "disconnected", close_code=ws.close_code)
+
+    async def _reject_hello(self, ws: ServerConnection, *, detail: str) -> None:
+        self.handshakes.resolve(ws, "bad-hello", close_code=4002, detail=detail)
+        await ws.close(code=4002, reason="expected a hello frame")
+
+    def _connection_class(self) -> type[ServerConnection]:
+        """A `ServerConnection` that reports the whole life of the TCP connection.
+
+        `_serve_addon` only runs once the HTTP upgrade has succeeded, so a client
+        that connects and never upgrades — which is exactly what Thunderbird did for
+        half an hour — is invisible to it. These two hooks are the only place that
+        sees it happen.
+        """
+        handshakes = self.handshakes
+
+        class TelemetryConnection(ServerConnection):
+            def connection_made(self, transport: asyncio.BaseTransport) -> None:
+                # After super(): it installs the transport that `remote_address`,
+                # and so the peer port, is read from.
+                super().connection_made(transport)
+                handshakes.opened(self)
+
+            def connection_lost(self, exc: Exception | None) -> None:
+                super().connection_lost(exc)
+                handshakes.resolve(self, "no-upgrade")
+
+        return TelemetryConnection
+
+    def _on_upgrade_request(self, conn: ServerConnection, request: Any) -> None:
+        """`process_request`: note who is dialling in, then accept by returning None."""
+        # Nothing here may raise: websockets turns an exception from process_request
+        # into a 500 and rejects the connection, which would make the telemetry the
+        # outage it is meant to explain.
+        with contextlib.suppress(Exception):
+            self.handshakes.note_request(
+                conn,
+                path=getattr(request, "path", None),
+                origin=request.headers.get("Origin"),
+                user_agent=request.headers.get("User-Agent"),
+            )
+        return None
+
+    def _addon_server(self, **overrides: Any) -> serve:
+        """The add-on listener, factored out so tests exercise the server `run` runs."""
+        kwargs: dict[str, Any] = {
+            "host": "127.0.0.1",
+            "port": 0,
+            "max_size": CHUNK_LIMIT * 2,
+            "create_connection": self._connection_class(),
+            "process_request": self._on_upgrade_request,
+        }
+        kwargs.update(overrides)
+        return serve(self._serve_addon, **kwargs)
 
     def _record_event(self, frame: dict[str, Any]) -> None:
         self.event_seq += 1
@@ -417,7 +506,7 @@ class Daemon:
             try:
                 await asyncio.wait_for(self._session_ready.wait(), timeout=wait)
             except TimeoutError:
-                raise NotConnectedError() from None
+                raise self._not_connected() from None
             return self.status()
         if method == "daemon.shutdown":
             self._stop.set()
@@ -425,8 +514,16 @@ class Daemon:
 
         session = self.session
         if session is None:
-            raise NotConnectedError()
+            raise self._not_connected()
         return await session.call(method, params, timeout=timeout, on_progress=on_progress)
+
+    def _not_connected(self) -> NotConnectedError:
+        """ "Not connected", carrying the diagnosis when we have one.
+
+        Every tool call that fails this way is someone asking why, so the answer
+        travels with the failure rather than waiting for them to run `doctor`.
+        """
+        return NotConnectedError(describe_handshake(self.handshakes.summary()))
 
     def status(self) -> dict[str, Any]:
         return {
@@ -440,6 +537,10 @@ class Daemon:
             "profile": {"path": str(self.profile.path), "name": self.profile.name},
             "thunderbird": self.session.describe() if self.session else None,
             "connected": self.session is not None,
+            "handshake": self.handshakes.summary(),
+            # Nothing the daemon logs reaches a terminal — it is spawned detached
+            # with its streams on DEVNULL — so every reporter needs the path.
+            "logFile": str(ipc.daemon_log_path()),
         }
 
     # ------------------------------------------------------------------ lifecycle
@@ -501,9 +602,7 @@ class Daemon:
             await asyncio.start_server(
                 self._serve_control, host="127.0.0.1", port=0, limit=ipc.MAX_LINE
             ) as control,
-            serve(
-                self._serve_addon, host="127.0.0.1", port=0, max_size=CHUNK_LIMIT * 2
-            ) as addon_server,
+            self._addon_server() as addon_server,
         ):
             control_port = control.sockets[0].getsockname()[1]
             addon_port = addon_server.sockets[0].getsockname()[1]

--- a/src/tbmcp/daemon.py
+++ b/src/tbmcp/daemon.py
@@ -560,9 +560,17 @@ class Daemon:
         log.info("pairing file written to %s (port %d)", path, port)
 
     def _cleanup(self) -> None:
-        with contextlib.suppress(OSError):
-            (self.profile.path / BRIDGE_FILE).unlink()
-        ipc.DaemonInfo.clear()
+        """Remove what we published — and only what is still ours.
+
+        A superseded daemon runs this on its way out too. Unlinking unconditionally
+        deleted the *winner's* pairing file and advertisement, which left the add-on
+        holding a token nothing was listening for and `serve` with nothing to find.
+        """
+        path = self.profile.path / BRIDGE_FILE
+        if _bridge_file_pid(path) == os.getpid():
+            with contextlib.suppress(OSError):
+                path.unlink()
+        ipc.DaemonInfo.clear_if_owned(os.getpid())
 
     async def _watch_idle(self) -> None:
         if self.idle_timeout <= 0:
@@ -632,6 +640,15 @@ class Daemon:
                     with contextlib.suppress(asyncio.CancelledError):
                         await task
                 self._cleanup()
+
+
+def _bridge_file_pid(path) -> int | None:
+    """The pid named by a pairing file, or None if it names nothing we can read."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        return int(payload["pid"])
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        return None
 
 
 async def run_daemon(

--- a/src/tbmcp/daemon.py
+++ b/src/tbmcp/daemon.py
@@ -41,6 +41,26 @@ DEFAULT_IDLE_TIMEOUT = 900.0
 ProgressCb = Callable[[dict[str, Any]], Awaitable[None]]
 
 
+def error_payload(exc: BaseException) -> dict[str, Any]:
+    """Serialise a failure into the protocol's `error` object.
+
+    Deliberately reads `.message` rather than `str(exc)`. `TbmcpError.__str__` renders
+    the code and the `needs` list into the text for humans, so relaying `str(exc)`
+    appended them again on every hop: a "not connected" that crossed the add-on, the
+    daemon and the bridge reached the caller as "... [NOT_CONNECTED] [NOT_CONNECTED]".
+    Reading the field back keeps a relayed error identical to the one that was sent.
+    """
+    payload: dict[str, Any] = {
+        "kind": getattr(exc, "kind", "internal"),
+        "code": getattr(exc, "code", None),
+        "message": getattr(exc, "message", None) or str(exc),
+    }
+    needs = getattr(exc, "needs", None)
+    if needs:
+        payload["needs"] = needs
+    return payload
+
+
 @dataclass
 class _Pending:
     future: asyncio.Future[Any]
@@ -365,18 +385,10 @@ class Daemon:
                 on_progress=forward_progress if wants_progress else None,
             )
         except Exception as exc:
-            kind = getattr(exc, "kind", "internal")
-            payload: dict[str, Any] = {
-                "kind": kind,
-                "code": getattr(exc, "code", None),
-                "message": str(exc),
-            }
-            needs = getattr(exc, "needs", None)
-            if needs:
-                payload["needs"] = needs
             with contextlib.suppress(Exception):
                 await ipc.write_message(
-                    writer, {"t": "res", "id": request_id, "ok": False, "error": payload}
+                    writer,
+                    {"t": "res", "id": request_id, "ok": False, "error": error_payload(exc)},
                 )
             return
         with contextlib.suppress(Exception):

--- a/src/tbmcp/daemon.py
+++ b/src/tbmcp/daemon.py
@@ -498,7 +498,9 @@ class Daemon:
 
     async def run(self) -> None:
         async with (
-            await asyncio.start_server(self._serve_control, host="127.0.0.1", port=0) as control,
+            await asyncio.start_server(
+                self._serve_control, host="127.0.0.1", port=0, limit=ipc.MAX_LINE
+            ) as control,
             serve(
                 self._serve_addon, host="127.0.0.1", port=0, max_size=CHUNK_LIMIT * 2
             ) as addon_server,

--- a/src/tbmcp/errors.py
+++ b/src/tbmcp/errors.py
@@ -3,11 +3,14 @@
 The `kind` values mirror `docs/PROTOCOL.md`. They exist so the tool layer can
 decide *how* a failure should reach the model:
 
-- `usage`, `blocked`, `unsupported`, `thunderbird` -> raise a plain exception, which
-  the SDK turns into `CallToolResult(is_error=True)`. The model sees the message and
-  can correct itself.
-- `internal` and transport failures -> also surfaced to the model, because a hidden
-  JSON-RPC error just looks like a hang from the user's side.
+- `usage`, `blocked`, `unsupported`, `thunderbird` -> raise one of these from the tool
+  body. `Registrar._add` re-raises anything derived from `TbmcpError` as the SDK's
+  `ToolError`, which is what turns it into a `CallToolResult(is_error=True)` carrying
+  the message; an exception the SDK reads as a crash reaches the model as nothing but
+  "Error executing tool <name>". So wrapped, the model sees the message and can
+  correct itself.
+- `internal` and transport failures -> the same path, because a hidden JSON-RPC error
+  just looks like a hang from the user's side.
 """
 
 from __future__ import annotations

--- a/src/tbmcp/handshake.py
+++ b/src/tbmcp/handshake.py
@@ -1,0 +1,255 @@
+"""What happened to each add-on connection before it was welcomed — and what to say.
+
+The daemon's WebSocket handler only runs once the HTTP upgrade has succeeded, so a
+connection that opens, sits there and closes is invisible to it: nothing is logged,
+nothing is counted, and every reporter downstream can only say "Thunderbird is not
+connected". That is exactly the shape of the outage this module was written for —
+thunderbird.exe dialling the add-on port twice every ~25 s for half an hour, each
+connection dying ~10 s later without ever upgrading.
+
+So the daemon records one `HandshakeAttempt` per TCP connection, from the moment the
+socket opens to whatever ended it, and `describe_handshake` turns that record into
+the paragraph `tb_status`, `tb_diagnostics` and `doctor` all put in front of the
+user. Pure and self-contained: it holds no sockets, only what became of them.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any
+from weakref import WeakKeyDictionary
+
+log = logging.getLogger("tbmcp.handshake")
+
+FAILED_BEFORE_HELLO = frozenset(
+    {
+        "no-upgrade",
+        "no-hello-timeout",
+        "closed-before-hello",
+        "bad-hello",
+        "bad-token",
+        "protocol-mismatch",
+        "non-loopback",
+    }
+)
+"""Outcomes that mean the add-on reached us and still never got welcomed. These are
+the ones worth counting: they say the pairing file was read and Thunderbird is
+running, so the fault is between those two facts and a working session."""
+
+_TERMINAL_AFTER_WELCOME = frozenset({"disconnected", "superseded"})
+
+#: Extra sentence per outcome, where the outcome narrows the cause down to one thing.
+_CAUSES = {
+    "no-upgrade": "The TCP connection opened but the WebSocket upgrade never completed.",
+    "bad-token": (
+        "It keeps presenting a stale token: a stray older `tbmcp daemon` may still be "
+        "running, or Thunderbird is using a different profile than the one the daemon "
+        "writes its pairing file into (pass `--profile`)."
+    ),
+    "protocol-mismatch": (
+        "The installed add-on speaks a different protocol version — `tbmcp install-addon`."
+    ),
+}
+
+
+@dataclass
+class HandshakeAttempt:
+    """One TCP connection to the add-on port, and what became of it."""
+
+    at: float
+    peer_port: int | None
+    outcome: str = "accepted"
+    close_code: int | None = None
+    detail: str | None = None
+    user_agent: str | None = None
+    origin: str | None = None
+    addon_version: str | None = None
+    resolved_at: float | None = None
+
+
+def _peer_port(key: Any) -> int | None:
+    """The port the peer dialled from, if the connection will say.
+
+    Two connections a second from the same client are otherwise indistinguishable
+    in a log; the ephemeral port is what lets a reader line an entry up against
+    `netstat` output.
+    """
+    address = getattr(key, "remote_address", None)
+    if isinstance(address, tuple) and len(address) >= 2:
+        try:
+            return int(address[1])
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
+class HandshakeLog:
+    """A short history of add-on connection attempts, keyed by the connection.
+
+    Keys are held weakly on purpose: a daemon that has been up for days must not
+    keep a dead `ServerConnection` — and its buffers — alive just because it once
+    recorded what happened to it. The records themselves live in the ring buffer.
+    """
+
+    def __init__(self, maxlen: int = 50, *, clock=time.time, window: float = 60.0) -> None:
+        self._attempts: deque[HandshakeAttempt] = deque(maxlen=maxlen)
+        self._by_key: WeakKeyDictionary[Any, HandshakeAttempt] = WeakKeyDictionary()
+        self._clock = clock
+        self._window = window
+        # Counted separately from the ring buffer, which caps at `maxlen`: an add-on
+        # reconnecting every 25 s fills any buffer long before anyone runs `doctor`.
+        self._total = 0
+
+    def opened(self, key: Any) -> HandshakeAttempt:
+        """Start (or return) the record for one connection. Idempotent per key."""
+        attempt = self._by_key.get(key)
+        if attempt is not None:
+            return attempt
+        attempt = HandshakeAttempt(at=self._clock(), peer_port=_peer_port(key))
+        self._by_key[key] = attempt
+        self._attempts.append(attempt)
+        self._total += 1
+        return attempt
+
+    def note_request(self, key: Any, *, path, origin, user_agent) -> None:
+        """Record the HTTP upgrade request, which is the last thing before the hello."""
+        attempt = self.opened(key)
+        attempt.origin = origin
+        attempt.user_agent = user_agent
+        if path and attempt.detail is None:
+            # Keeping the path separates "nothing was ever sent" from "it asked for
+            # our endpoint and then died"; a real outcome's detail replaces it.
+            attempt.detail = str(path)
+
+    def resolve(
+        self,
+        key: Any,
+        outcome: str,
+        *,
+        close_code: int | None = None,
+        detail: str | None = None,
+        addon_version: str | None = None,
+    ) -> None:
+        """Record how a connection ended, unless it has already been decided.
+
+        The first diagnosis wins. `connection_lost` fires for every connection,
+        including one the handler has already rejected by name, so without this the
+        specific outcome would be overwritten by the generic hook behind it. A
+        welcomed session is the one case that legitimately moves on — to
+        `disconnected`, or to `superseded` when we replace it ourselves.
+        """
+        attempt = self.opened(key)
+        current = attempt.outcome
+        if current != "accepted" and not (
+            current == "welcomed" and outcome in _TERMINAL_AFTER_WELCOME
+        ):
+            return
+        attempt.outcome = outcome
+        attempt.resolved_at = self._clock()
+        if close_code is not None:
+            attempt.close_code = close_code
+        if detail is not None:
+            attempt.detail = detail
+        if addon_version is not None:
+            attempt.addon_version = addon_version
+        self._report(attempt)
+
+    def _report(self, attempt: HandshakeAttempt) -> None:
+        parts: list[str] = []
+        if attempt.peer_port is not None:
+            parts.append(f"peer port {attempt.peer_port}")
+        if attempt.user_agent:
+            parts.append(attempt.user_agent)
+        if attempt.addon_version:
+            parts.append(f"add-on {attempt.addon_version}")
+        if attempt.resolved_at is not None:
+            parts.append(f"after {attempt.resolved_at - attempt.at:.1f}s")
+        if attempt.detail:
+            parts.append(attempt.detail)
+        where = ", ".join(parts)
+        if attempt.outcome in FAILED_BEFORE_HELLO:
+            log.warning("add-on handshake failed: %s (%s)", attempt.outcome, where)
+        else:
+            log.info("add-on handshake %s (%s)", attempt.outcome, where)
+
+    def summary(self) -> dict[str, Any]:
+        """Everything a reporter needs, JSON-safe, oldest attempt first."""
+        cutoff = self._clock() - self._window
+        recent = [attempt for attempt in self._attempts if attempt.at >= cutoff]
+        outcomes: dict[str, int] = {}
+        for attempt in recent:
+            outcomes[attempt.outcome] = outcomes.get(attempt.outcome, 0) + 1
+        last = self._attempts[-1] if self._attempts else None
+        return {
+            "attempts": self._total,
+            "lastAttemptAt": last.at if last else None,
+            "lastOutcome": last.outcome if last else None,
+            "lastCloseCode": last.close_code if last else None,
+            "lastUserAgent": last.user_agent if last else None,
+            "recentFailures": sum(1 for a in recent if a.outcome in FAILED_BEFORE_HELLO),
+            "recentOutcomes": outcomes,
+            "windowSeconds": self._window,
+            "recent": [_compact(attempt) for attempt in list(self._attempts)[-10:]],
+        }
+
+
+def _compact(attempt: HandshakeAttempt) -> dict[str, Any]:
+    """One attempt with its unknowns dropped — these end up in `doctor --json`."""
+    row: dict[str, Any] = {"at": round(attempt.at, 3), "outcome": attempt.outcome}
+    optional = {
+        "peerPort": attempt.peer_port,
+        "closeCode": attempt.close_code,
+        "detail": attempt.detail,
+        "userAgent": attempt.user_agent,
+        "addonVersion": attempt.addon_version,
+    }
+    row.update({name: value for name, value in optional.items() if value is not None})
+    if attempt.resolved_at is not None:
+        row["seconds"] = round(attempt.resolved_at - attempt.at, 3)
+    return row
+
+
+def _last_failure(summary: dict[str, Any]) -> tuple[str | None, float | None]:
+    """The most recent attempt that failed before being welcomed.
+
+    Not simply `lastOutcome`: an add-on that flaps gets welcomed between failures,
+    and naming the connection that worked would send the reader looking in the
+    wrong place.
+    """
+    for row in reversed(summary.get("recent") or []):
+        if isinstance(row, dict) and row.get("outcome") in FAILED_BEFORE_HELLO:
+            return str(row.get("outcome")), row.get("at")
+    return summary.get("lastOutcome"), summary.get("lastAttemptAt")
+
+
+def describe_handshake(summary: dict[str, Any] | None) -> str | None:
+    """One paragraph explaining repeated handshake failures, or `None` if there are
+    none — so a caller can write `describe_handshake(...) or <the usual hint>`."""
+    if not summary:
+        return None
+    failures = int(summary.get("recentFailures") or 0)
+    if failures <= 0:
+        return None
+
+    window = float(summary.get("windowSeconds") or 60.0)
+    outcome, at = _last_failure(summary)
+    when = ""
+    if isinstance(at, (int, float)):
+        age = time.time() - at
+        if age >= 0:
+            when = f", {age:.0f} s ago"
+
+    text = (
+        f"Thunderbird's add-on reached the daemon {failures} "
+        f"{'time' if failures == 1 else 'times'} in the last {window:g} s but never "
+        f"completed the handshake (last: {outcome}{when}). Thunderbird is running and "
+        "can read the pairing file, so the add-on is failing before it is welcomed. "
+        "Restart Thunderbird; if it recurs, open its Error Console (Ctrl+Shift+J), "
+        "filter on `[tbmcp]`, and reinstall the add-on to match this package: "
+        "`tbmcp install-addon`."
+    )
+    cause = _CAUSES.get(str(outcome))
+    return f"{text} {cause}" if cause else text

--- a/src/tbmcp/ipc.py
+++ b/src/tbmcp/ipc.py
@@ -115,6 +115,25 @@ class DaemonInfo:
         except FileNotFoundError:
             pass
 
+    @classmethod
+    def clear_if_owned(cls, pid: int) -> None:
+        """Withdraw the advertisement only while it still names `pid`.
+
+        A daemon that stands down because another one took the advertisement over
+        must not delete the winner's file on its way out — that leaves `serve` with
+        nothing to find and two healthy processes looking blameless.
+
+        Reads the raw file rather than `load()`: what matters here is who wrote it,
+        not whether that process is still alive or speaks our protocol version.
+        """
+        try:
+            raw = json.loads(cls.path().read_text(encoding="utf-8"))
+            owner = int(raw["pid"])
+        except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+            return
+        if owner == pid:
+            cls.clear()
+
 
 def _restrict_permissions(path: Path) -> None:
     """Best-effort: make the token file readable only by this user."""

--- a/src/tbmcp/ipc.py
+++ b/src/tbmcp/ipc.py
@@ -22,8 +22,17 @@ MAX_LINE = 64 * 1024 * 1024  # a raw message body can legitimately be large
 
 
 def state_dir() -> Path:
-    """Per-user directory for the daemon advertisement and lock."""
-    if sys.platform == "win32":
+    """Per-user directory for the daemon advertisement, lock and log.
+
+    `TBMCP_STATE_DIR` overrides the platform default on every platform. macOS has
+    no conventional environment variable for this directory, so without an
+    explicit override there is no way for a test — or a CI job — to keep the
+    daemon's files out of the user's real ~/Library.
+    """
+    override = os.environ.get("TBMCP_STATE_DIR")
+    if override:
+        base = override
+    elif sys.platform == "win32":
         base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
     elif sys.platform == "darwin":
         base = str(Path.home() / "Library" / "Application Support")

--- a/src/tbmcp/ipc.py
+++ b/src/tbmcp/ipc.py
@@ -34,6 +34,16 @@ def state_dir() -> Path:
     return path
 
 
+def daemon_log_path() -> Path:
+    """Where the daemon keeps its log.
+
+    The daemon is spawned detached with its streams on DEVNULL, so everything it
+    logs is discarded the moment it is written. One known path is what turns "the
+    bridge went quiet" into something anyone can read after the fact.
+    """
+    return state_dir() / "daemon.log"
+
+
 @dataclass
 class DaemonInfo:
     """Contents of `<state_dir>/daemon.json` — how `serve` finds the daemon."""

--- a/src/tbmcp/ipc.py
+++ b/src/tbmcp/ipc.py
@@ -224,11 +224,19 @@ def new_token() -> str:
 
 
 async def read_message(reader: asyncio.StreamReader) -> dict[str, Any] | None:
-    """Read one newline-delimited JSON object. `None` means the peer hung up."""
+    """Read one newline-delimited JSON object. `None` means the peer hung up.
+
+    Both ends must open their streams with `limit=MAX_LINE`; asyncio's own default is
+    64 KiB, which is far below what a legitimate frame can be. A frame past the
+    reader's buffer is not truncated but abandoned, and `readline()` reports that as a
+    bare `ValueError` — untyped, it looked to the caller like the peer disconnecting.
+    """
     try:
         line = await reader.readline()
     except (asyncio.IncompleteReadError, ConnectionResetError):
         return None
+    except ValueError as exc:
+        raise TransportError("control message exceeded the maximum size", code="TOO_LARGE") from exc
     if not line:
         return None
     if len(line) > MAX_LINE:

--- a/src/tbmcp/server.py
+++ b/src/tbmcp/server.py
@@ -199,4 +199,4 @@ def _version() -> str:
 
         return version("thunderbird-mcp")
     except Exception:
-        return "1.2.1"
+        return "1.3.0"

--- a/src/tbmcp/server.py
+++ b/src/tbmcp/server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import functools
 import importlib
 import inspect
 import logging
@@ -9,11 +10,13 @@ from collections.abc import Callable
 from typing import Any, TypeVar
 
 from mcp.server.mcpserver import MCPServer
+from mcp.server.mcpserver.exceptions import ToolError
 from mcp.types import ToolAnnotations
 
 from . import safety
 from .bridge import Bridge, set_shared_bridge
 from .config import ALL_TOOLSETS, Settings
+from .errors import TbmcpError
 
 log = logging.getLogger("tbmcp.server")
 
@@ -47,6 +50,27 @@ Notes that will save you a round trip:
 """
 
 
+def _as_tool_error(fn: F) -> F:
+    """Wrap a tool so the failures it raises on purpose reach the model.
+
+    The SDK tells a deliberate `ToolError` from a crash, and mcp >= 2.1 withholds a
+    crash's text entirely: the model is handed "Error executing tool <name>" and
+    nothing else, so a `UsageError` naming the parameter to fix arrived with nothing
+    to act on. Re-raising ours as `ToolError` keeps the message (both supported
+    versions prefix it with the tool name and keep the rest) and keeps a traceback out
+    of the log for something we decided ourselves. Anything else is still a crash.
+    """
+
+    @functools.wraps(fn)
+    async def guarded(*args: Any, **kwargs: Any) -> Any:
+        try:
+            return await fn(*args, **kwargs)
+        except TbmcpError as exc:
+            raise ToolError(str(exc)) from exc
+
+    return guarded  # type: ignore[return-value]
+
+
 class Registrar:
     """Registers tools with consistent annotations, and drops writes in read-only mode."""
 
@@ -69,7 +93,7 @@ class Registrar:
             self.skipped.append(fn.__name__)
             return fn
         self.mcp.add_tool(
-            fn,
+            _as_tool_error(fn),
             title=title,
             # Normalise the docstring ourselves rather than letting the interpreter
             # decide: CPython 3.13 strips common leading whitespace from `__doc__` at

--- a/src/tbmcp/tools/admin.py
+++ b/src/tbmcp/tools/admin.py
@@ -145,6 +145,9 @@ def register(reg: Registrar) -> None:
         Narrow it with `contains` — `tbmcp` shows this bridge's own complaints, and an
         add-on id or a source filename shows someone else's. Anything shaped like a
         password or token is redacted inside Thunderbird before it is sent.
+
+        Lines the bridge writes with `console.*` (`source: "console"`) are included
+        alongside the error console's own entries, merged by time.
         """
         result = await call(
             "x.admin.consoleMessages",

--- a/src/tbmcp/tools/admin.py
+++ b/src/tbmcp/tools/admin.py
@@ -13,6 +13,7 @@ guess at a timeout.
 from typing import Any, Literal
 
 from ..errors import TbmcpError
+from ..handshake import describe_handshake
 from ..safety import DESTRUCTIVE, Gate, guard_write, large_output, require
 from ..server import Registrar
 from ._common import call, changed, clamp, one_of, page
@@ -52,9 +53,13 @@ def register(reg: Registrar) -> None:
             "inFlightCalls": thunderbird.get("inFlight"),
             "profile": result.get("profile"),
             "daemon": result.get("daemon"),
+            # What the add-on's connection attempts did, welcomed or not. "Not
+            # connected" and "connecting twice a minute and failing" need opposite
+            # advice, and only this tells them apart.
+            "handshake": result.get("handshake"),
         }
         if not payload["connected"]:
-            payload["hint"] = NOT_CONNECTED_HINT
+            payload["hint"] = describe_handshake(result.get("handshake")) or NOT_CONNECTED_HINT
         elif payload["privilegedHalf"] is False:
             payload["hint"] = NO_EXPERIMENT_HINT
         return payload
@@ -121,9 +126,10 @@ def register(reg: Registrar) -> None:
             "daemon": status.get("daemon"),
             "profile": status.get("profile"),
             "thunderbird": status.get("thunderbird"),
+            "handshake": status.get("handshake"),
         }
         if not payload["connected"]:
-            payload["hint"] = NOT_CONNECTED_HINT
+            payload["hint"] = describe_handshake(status.get("handshake")) or NOT_CONNECTED_HINT
             return payload
         try:
             payload.update(await call("x.admin.diagnostics", timeout=60.0))

--- a/src/tbmcp/tools/mail.py
+++ b/src/tbmcp/tools/mail.py
@@ -132,12 +132,18 @@ def register(reg: Registrar) -> None:
             },
             timeout=90.0,
         )
+        # A null field reads to a model as a fact about the mailbox, so anything
+        # the add-on did not send is left out rather than sent as null. `scope`
+        # comes with a first page only; a continuation is by definition the same
+        # search.
+        reported = {
+            key: result[key] for key in ("scope", "indexNote") if result.get(key) is not None
+        }
         return page(
             [message_summary(m) for m in result.get("messages", [])],
             cursor=result.get("cursor"),
             total=result.get("totalAvailable"),
-            searchedFolders=result.get("searchedFolders"),
-            indexNote=result.get("indexNote"),
+            **reported,
         )
 
     @reg.read_tool(title="List a folder")

--- a/src/tbmcp/tools/mail.py
+++ b/src/tbmcp/tools/mail.py
@@ -70,7 +70,9 @@ def register(reg: Registrar) -> None:
         `full_text` uses Thunderbird's global index and searches headers and bodies
         of already-indexed messages; `subject`/`author`/`body` are substring matches
         evaluated per folder. Dates are ISO-8601. Results are summaries — call
-        `mail_get` for a body. Continue with `cursor=nextCursor`.
+        `mail_get` for a body. Continue with `cursor=nextCursor`. A first page
+        carries `scope` — the folder and account ids the query covered — so an empty
+        result can be read against what was actually searched.
         """
         query: dict[str, Any] = {}
         if full_text:

--- a/src/tbmcp/tools/search.py
+++ b/src/tbmcp/tools/search.py
@@ -116,6 +116,13 @@ def register(reg: Registrar) -> None:
 
         If this returns nothing unexpectedly, call `search_index_status`: the global
         indexer can be disabled or still catching up.
+
+        `matched` is how many of the retrieved messages matched, and it is the
+        total only when `truncated` is absent; a truncated search ranked as deep
+        as it could and there may be more below. `unmatchableTerms` names words
+        the index cannot look up at all — anything that breaks into pieces of
+        fewer than three characters, like "2.0" — and because every term has to
+        match, one of those is enough to empty the result.
         """
         if not query or not query.strip():
             raise UsageError("query is required — pass the words to search for.")
@@ -130,12 +137,22 @@ def register(reg: Registrar) -> None:
             timeout=120.0,
         )
         hits = result.get("hits") or result.get("messages") or []
+        truncated = bool(result.get("truncated"))
+        # A null field reads to a model as a fact about the mailbox, so anything
+        # the add-on did not send is left out rather than sent as null.
+        reported = {
+            key: result[key]
+            for key in ("matched", "retrieved", "indexEnabled", "unmatchableTerms", "note")
+            if result.get(key) is not None
+        }
         return page(
             hits,
-            total=result.get("totalMatched"),
-            indexEnabled=result.get("indexEnabled"),
-            note=result.get("note"),
+            # `matched` counts what the ranking saw. Once the retrieval was cut
+            # short that is no longer a total of anything.
+            total=None if truncated else result.get("matched"),
+            truncated=truncated,
             query=query,
+            **reported,
         )
 
     @reg.read_tool(title="Read a whole conversation", meta=large_output())
@@ -160,11 +177,16 @@ def register(reg: Registrar) -> None:
         else:
             params["headerMessageId"] = header_message_id
         result = await call("x.gloda.conversation", params, timeout=120.0)
+        known = {
+            key: result[key]
+            for key in ("conversationId", "subject", "participants")
+            if result.get(key) is not None
+        }
         return page(
             result.get("messages") or [],
-            conversationId=result.get("conversationId"),
-            subject=result.get("subject"),
-            participants=result.get("participants"),
+            # The thread can be longer than the page asked for.
+            total=result.get("total"),
+            **known,
         )
 
     @reg.read_tool(title="Global index status")

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -1,0 +1,12 @@
+# Add-on tests
+
+    node --test "tests/js/*.test.mjs"
+
+Node built-ins only, no npm. `harness.mjs` evaluates a script from `addon/` in a
+`node:vm` context and hands it fakes: `fakeBrowser` (the WebExtension and
+experiment APIs, including the pairing file), `fakeWebSocketClass` (a socket the
+test plays the daemon on), `fakeClock` (timers a test advances by hand) and
+`fakeLog`. Nothing here starts, installs or talks to a real Thunderbird, and no
+test touches the network or the profile directory.
+
+Quote the glob: some Node builds run a bare `tests/js` argument as a file.

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -8,3 +8,10 @@ Node built-ins only, no npm. `harness.mjs` runs a script from `addon/` in a
 `node:vm` context with fakes for the browser and experiment APIs (the pairing
 file included), the WebSocket, the clock and the log. Nothing here installs,
 starts or talks to a real Thunderbird, and no test touches the network.
+
+The privileged half is tested the same way. `loadExperiment` reproduces the
+build step — `experiment/core.js` with the named `experiment/modules/*.js`
+spliced in at the marker — and runs it against `fakeSandbox`, which injects what
+Thunderbird's ext-\*.js sandbox injects and, deliberately, none of the DOM
+globals that sandbox does not have. Block-scoped helpers reach a test through
+`TBX_TEST_HOOKS`, which is undefined in Thunderbird.

--- a/tests/js/README.md
+++ b/tests/js/README.md
@@ -2,11 +2,9 @@
 
     node --test "tests/js/*.test.mjs"
 
-Node built-ins only, no npm. `harness.mjs` evaluates a script from `addon/` in a
-`node:vm` context and hands it fakes: `fakeBrowser` (the WebExtension and
-experiment APIs, including the pairing file), `fakeWebSocketClass` (a socket the
-test plays the daemon on), `fakeClock` (timers a test advances by hand) and
-`fakeLog`. Nothing here starts, installs or talks to a real Thunderbird, and no
-test touches the network or the profile directory.
-
 Quote the glob: some Node builds run a bare `tests/js` argument as a file.
+
+Node built-ins only, no npm. `harness.mjs` runs a script from `addon/` in a
+`node:vm` context with fakes for the browser and experiment APIs (the pairing
+file included), the WebSocket, the clock and the log. Nothing here installs,
+starts or talks to a real Thunderbird, and no test touches the network.

--- a/tests/js/admin.test.mjs
+++ b/tests/js/admin.test.mjs
@@ -1,0 +1,195 @@
+/* The error console, as read from inside Thunderbird.
+ *
+ * `tb_console` exists to answer "what did the bridge complain about?", and it
+ * could not: an extension page's `console.*` output goes to the ConsoleAPI
+ * storage, not to `Services.console`, so every `[tbmcp]` line the add-on writes
+ * was invisible to the one tool meant to surface it. Reading both stores is the
+ * fix, and reading *only our own* events out of the second one is the constraint
+ * — that store holds every other add-on's output too.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { fakeSandbox, loadExperiment } from "./harness.mjs";
+
+const ADDON_ID = "bridge@thunderbird-mcp";
+const BASE_URL = "moz-extension://11111111-2222-3333-4444-555555555555/";
+const STORAGE = "@mozilla.org/consoleAPI-storage;1";
+
+/** Values built inside the vm carry that realm's prototypes; strip them. */
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** An `nsIScriptError` as `Services.console.getMessageArray()` hands it over. */
+function systemEntry(message, at) {
+  return {
+    message,
+    QueryInterface: () => ({
+      flags: 0,
+      category: "chrome javascript",
+      sourceName: "chrome://tbmcp/content/x.js",
+      lineNumber: 12,
+      timeStamp: at,
+    }),
+  };
+}
+
+/** A ConsoleAPI event, as an extension page's `console.*` leaves it. */
+function consoleEvent({ level = "log", args, at, addonId, innerID }) {
+  return { level, arguments: args, timeStamp: at, addonId, innerID };
+}
+
+/**
+ * The admin module over both console stores.
+ *
+ * `getAPI` is called because that is where the add-on learns its own id — the
+ * privileged half has no other way to know which events are its own.
+ */
+function experiment({ system = [], events = [], storageFails = false, identify = true } = {}) {
+  const globals = fakeSandbox();
+  globals.Ci = {
+    nsIScriptError: { warningFlag: 1 },
+    nsIConsoleAPIStorage: "nsIConsoleAPIStorage",
+  };
+  globals.Services = { ...globals.Services, console: { getMessageArray: () => system } };
+  globals.Cc = {
+    [STORAGE]: {
+      getService() {
+        if (storageFails) {
+          throw new Error("no such service");
+        }
+        return { getEvents: () => events };
+      },
+    },
+  };
+  const ctx = loadExperiment(globals, { modules: ["admin"] });
+  if (identify) {
+    new ctx.tbx().getAPI({ extension: { id: ADDON_ID, baseURL: BASE_URL } });
+  }
+  return (params) => ctx.TBX_TEST_HOOKS.core.handlers["admin.consoleMessages"](params || {});
+}
+
+const AT = Date.parse("2026-09-08T15:00:00.000Z");
+
+describe("admin.consoleMessages", () => {
+  it("includes the add-on's own console output, which Services.console never holds", async () => {
+    const call = experiment({
+      events: [
+        consoleEvent({ level: "warn", args: ["[tbmcp]", "no welcome"], at: AT, addonId: ADDON_ID }),
+      ],
+    });
+
+    const result = await call({});
+
+    assert.deepEqual(plain(result.messages), [
+      {
+        at: new Date(AT).toISOString(),
+        severity: "warn",
+        message: "[tbmcp] no welcome",
+        source: "console",
+      },
+    ]);
+  });
+
+  it("leaves another add-on's console output where it found it", async () => {
+    const call = experiment({
+      events: [
+        consoleEvent({ args: ["ours"], at: AT, addonId: ADDON_ID }),
+        consoleEvent({ args: ["theirs"], at: AT + 1, addonId: "someone@else" }),
+        consoleEvent({ args: ["nobody's"], at: AT + 2, innerID: "moz-extension://other/x.js" }),
+      ],
+    });
+
+    const result = await call({});
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["ours"]
+    );
+  });
+
+  it("recognises an event by its innerID when it carries no addonId", async () => {
+    const call = experiment({
+      events: [consoleEvent({ args: ["from our page"], at: AT, innerID: `${BASE_URL}background.js` })],
+    });
+
+    const result = await call({});
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["from our page"]
+    );
+  });
+
+  it("merges the two stores in time order, newest last", async () => {
+    const call = experiment({
+      system: [systemEntry("first, from XPCOM", AT), systemEntry("third, from XPCOM", AT + 2000)],
+      events: [consoleEvent({ args: ["second, from us"], at: AT + 1000, addonId: ADDON_ID })],
+    });
+
+    const result = await call({});
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["first, from XPCOM", "second, from us", "third, from XPCOM"]
+    );
+    assert.equal(result.buffered, 3);
+  });
+
+  it("redacts our own lines too — a token in a log is still a token", async () => {
+    const call = experiment({
+      events: [
+        consoleEvent({ args: ["[tbmcp] token: abcd1234efgh"], at: AT, addonId: ADDON_ID }),
+      ],
+    });
+
+    const result = await call({});
+
+    assert.match(result.messages[0].message, /<redacted>/);
+    assert.doesNotMatch(result.messages[0].message, /abcd1234efgh/);
+  });
+
+  it("filters across both stores", async () => {
+    const call = experiment({
+      system: [systemEntry("unrelated warning", AT)],
+      events: [consoleEvent({ args: ["[tbmcp] connecting"], at: AT + 1, addonId: ADDON_ID })],
+    });
+
+    const result = await call({ filter: "tbmcp" });
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["[tbmcp] connecting"]
+    );
+    assert.equal(result.matched, 1);
+    assert.equal(result.buffered, 2);
+  });
+
+  it("still answers when this build has no ConsoleAPI storage", async () => {
+    const call = experiment({ system: [systemEntry("from XPCOM", AT)], storageFails: true });
+
+    const result = await call({});
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["from XPCOM"]
+    );
+  });
+
+  it("claims no events at all until it knows which add-on it is", async () => {
+    const call = experiment({
+      system: [systemEntry("from XPCOM", AT)],
+      events: [consoleEvent({ args: ["ours"], at: AT + 1, addonId: ADDON_ID })],
+      identify: false,
+    });
+
+    const result = await call({});
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["from XPCOM"]
+    );
+  });
+});

--- a/tests/js/admin.test.mjs
+++ b/tests/js/admin.test.mjs
@@ -36,6 +36,18 @@ function systemEntry(message, at) {
   };
 }
 
+/** A plain nsIConsoleMessage: no QueryInterface to nsIScriptError, no timestamp
+ *  unless the caller says so — console.log output and XPCOM warnings look like this. */
+function plainEntry(message, at) {
+  return {
+    message,
+    timeStamp: at,
+    QueryInterface: () => {
+      throw new Error("NS_NOINTERFACE");
+    },
+  };
+}
+
 /** A ConsoleAPI event, as an extension page's `console.*` leaves it. */
 function consoleEvent({ level = "log", args, at, addonId, innerID }) {
   return { level, arguments: args, timeStamp: at, addonId, innerID };
@@ -190,6 +202,39 @@ describe("admin.consoleMessages", () => {
     assert.deepEqual(
       plain(result.messages.map((row) => row.message)),
       ["from XPCOM"]
+    );
+  });
+
+  it("keeps a plain console message in its place, and never drops it first", async () => {
+    // A plain nsIConsoleMessage carries its time on the entry itself. Sorting it
+    // as "oldest" put every such line at the front, where `limit` trims first —
+    // the newest [tbmcp] warning was the first thing to disappear.
+    const call = experiment({
+      system: [
+        systemEntry("old script error", AT),
+        plainEntry("newest plain message", AT + 5000),
+      ],
+      events: [consoleEvent({ args: ["ours, in between"], at: AT + 1000, addonId: ADDON_ID })],
+    });
+
+    const result = await call({ limit: 2 });
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["ours, in between", "newest plain message"]
+    );
+  });
+
+  it("keeps store order for entries with no time at all", async () => {
+    const call = experiment({
+      system: [plainEntry("first, untimed"), plainEntry("second, untimed")],
+    });
+
+    const result = await call({});
+
+    assert.deepEqual(
+      plain(result.messages.map((row) => row.message)),
+      ["first, untimed", "second, untimed"]
     );
   });
 });

--- a/tests/js/core.test.mjs
+++ b/tests/js/core.test.mjs
@@ -1,0 +1,37 @@
+/* The privileged half's own plumbing: deadlines and the error envelope.
+ *
+ * Both defects these cover were invisible from the outside. The sandbox has no
+ * DOM globals, so every `H.withTimeout` deadline threw a ReferenceError before
+ * the work it guarded even started; and an Error thrown from a system-principal
+ * sandbox loses its message on the way to the background page, which is why the
+ * envelope below is a string the other side can parse rather than an object.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { fakeSandbox, loadExperiment } from "./harness.mjs";
+
+const TIMER_URL = "resource://gre/modules/Timer.sys.mjs";
+
+describe("H.withTimeout", () => {
+  it("rejects with its own deadline, in a sandbox that has no DOM timers", async () => {
+    const ctx = loadExperiment(fakeSandbox());
+    const { H } = ctx.TBX_TEST_HOOKS.core;
+
+    await assert.rejects(H.withTimeout(new Promise(() => {}), 20, "gloda search"), (ex) => {
+      assert.match(String(ex.message), /gloda search timed out after 20ms/);
+      return true;
+    });
+  });
+
+  it("clears the timer when the guarded work wins the race", async () => {
+    const globals = fakeSandbox();
+    const timer = globals.ChromeUtils.importESModule(TIMER_URL);
+    const ctx = loadExperiment(globals);
+    const { H } = ctx.TBX_TEST_HOOKS.core;
+
+    assert.equal(await H.withTimeout(Promise.resolve(7), 20, "a fast one"), 7);
+    assert.equal(timer.cleared.length, 1, "an armed timer outlives the call that armed it");
+  });
+});

--- a/tests/js/core.test.mjs
+++ b/tests/js/core.test.mjs
@@ -36,23 +36,32 @@ describe("H.withTimeout", () => {
   });
 });
 
-/** The dispatch entry point, plus the lexical helpers a test needs to drive it. */
-function experiment(globals = fakeSandbox()) {
+/** The whole privileged API, plus the lexical helpers a test needs to drive it. */
+function experiment(globals = fakeSandbox(), extension = {}) {
   const ctx = loadExperiment(globals);
-  const api = new ctx.tbx().getAPI({ extension: {} }).tbx;
-  return { hooks: ctx.TBX_TEST_HOOKS.core, invoke: (method, params) => api.invoke(method, params) };
+  const api = new ctx.tbx().getAPI({ extension }).tbx;
+  return {
+    api,
+    hooks: ctx.TBX_TEST_HOOKS.core,
+    invoke: (method, params) => api.invoke(method, params),
+  };
 }
 
-/** The payload the background page gets to parse out of a failed invoke. */
-async function envelope(promise) {
+/** The error a call failed with, whatever realm minted it. */
+async function rejection(promise) {
   try {
     await promise;
   } catch (ex) {
-    const message = String(ex.message);
-    assert.ok(message.startsWith("tbxerr:"), `not a tagged error: ${message}`);
-    return JSON.parse(message.slice("tbxerr:".length));
+    return ex;
   }
-  assert.fail("the call was expected to fail");
+  return assert.fail("the call was expected to fail");
+}
+
+/** The payload the background page gets to parse out of a failed call. */
+async function envelope(promise) {
+  const message = String((await rejection(promise)).message);
+  assert.ok(message.startsWith("tbxerr:"), `not a tagged error: ${message}`);
+  return JSON.parse(message.slice("tbxerr:".length));
 }
 
 describe("invoke", () => {
@@ -123,5 +132,40 @@ describe("invoke", () => {
 
     // A plain object is the only other shape normalizeError keeps a message for.
     assert.equal((await envelope(invoke("test.thing", {}))).message, "subject is required");
+  });
+});
+
+describe("the rest of the API surface", () => {
+  it("packs a blocked write into the envelope, though it never goes through invoke", async () => {
+    const globals = fakeSandbox();
+    globals.IOUtils = { ...globals.IOUtils, exists: async () => true };
+    const { api } = experiment(globals);
+
+    const failure = await rejection(
+      api.writeFile({ directory: "/out", filename: "invoice.pdf", base64: "", overwrite: false })
+    );
+
+    assert.equal(failure.constructor.name, "ExtensionError");
+    assert.ok(String(failure.message).startsWith("tbxerr:"));
+    const payload = JSON.parse(String(failure.message).slice("tbxerr:".length));
+    assert.equal(payload.kind, "blocked");
+    assert.match(payload.message, /already exists/);
+    assert.match(payload.needs.join(" "), /overwrite=true/);
+  });
+
+  it("packs a usage failure from a method that is not invoke", async () => {
+    const extension = { hasPermission: () => false, manifest: { optional_permissions: [] } };
+    const { api } = experiment(fakeSandbox(), extension);
+
+    const payload = await envelope(api.grantOptionalPermission("messages.send"));
+
+    assert.equal(payload.kind, "usage");
+    assert.match(payload.message, /optional_permissions/);
+  });
+
+  it("leaves a method that succeeds alone", async () => {
+    const { api } = experiment();
+
+    assert.equal((await api.appInfo()).name, "Thunderbird");
   });
 });

--- a/tests/js/core.test.mjs
+++ b/tests/js/core.test.mjs
@@ -35,3 +35,93 @@ describe("H.withTimeout", () => {
     assert.equal(timer.cleared.length, 1, "an armed timer outlives the call that armed it");
   });
 });
+
+/** The dispatch entry point, plus the lexical helpers a test needs to drive it. */
+function experiment(globals = fakeSandbox()) {
+  const ctx = loadExperiment(globals);
+  const api = new ctx.tbx().getAPI({ extension: {} }).tbx;
+  return { hooks: ctx.TBX_TEST_HOOKS.core, invoke: (method, params) => api.invoke(method, params) };
+}
+
+/** The payload the background page gets to parse out of a failed invoke. */
+async function envelope(promise) {
+  try {
+    await promise;
+  } catch (ex) {
+    const message = String(ex.message);
+    assert.ok(message.startsWith("tbxerr:"), `not a tagged error: ${message}`);
+    return JSON.parse(message.slice("tbxerr:".length));
+  }
+  assert.fail("the call was expected to fail");
+}
+
+describe("invoke", () => {
+  it("packs a usage failure into an envelope, because a bare Error loses its message", async () => {
+    const { hooks, invoke } = experiment();
+    hooks.handlers["test.thing"] = async () => {
+      throw hooks.H.usage("subject is required");
+    };
+
+    assert.deepEqual(await envelope(invoke("test.thing", {})), {
+      kind: "usage",
+      message: "subject is required",
+      code: null,
+    });
+  });
+
+  it("carries what a blocked failure needs to go through", async () => {
+    const { hooks, invoke } = experiment();
+    hooks.handlers["test.thing"] = async () => {
+      throw hooks.H.blocked("exists", "overwrite=true");
+    };
+
+    assert.deepEqual(await envelope(invoke("test.thing", {})), {
+      kind: "blocked",
+      message: "exists",
+      code: null,
+      needs: ["overwrite=true"],
+    });
+  });
+
+  it("reports an untyped failure as Thunderbird's, with no code worth quoting", async () => {
+    const { hooks, invoke } = experiment();
+    hooks.handlers["test.thing"] = async () => {
+      throw new Error("boom");
+    };
+
+    assert.deepEqual(await envelope(invoke("test.thing", {})), {
+      kind: "thunderbird",
+      message: "boom",
+      code: null,
+    });
+  });
+
+  it("keeps a subclass name as the code", async () => {
+    const { hooks, invoke } = experiment();
+    hooks.handlers["test.thing"] = async () => {
+      throw new TypeError("t");
+    };
+
+    assert.equal((await envelope(invoke("test.thing", {}))).code, "TypeError");
+  });
+
+  it("names the method it does not know", async () => {
+    const { invoke } = experiment();
+
+    const payload = await envelope(invoke("nope.thing", {}));
+    assert.equal(payload.kind, "usage");
+    assert.match(payload.message, /nope\.thing/);
+  });
+
+  it("still reports a message when ExtensionError is not there to carry it", async () => {
+    const { hooks, invoke } = experiment(
+      fakeSandbox({ modules: { "resource://gre/modules/ExtensionUtils.sys.mjs": {} } })
+    );
+    hooks.handlers["test.thing"] = async () => {
+      throw hooks.H.usage("subject is required");
+    };
+
+    // A plain object is the only other shape normalizeError keeps a message for.
+    assert.equal((await envelope(invoke("test.thing", {}))).message, "subject is required");
+  });
+});

--- a/tests/js/gloda.test.mjs
+++ b/tests/js/gloda.test.mjs
@@ -10,22 +10,65 @@ import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 import vm from "node:vm";
 
-import { fakeSandbox, loadExperiment } from "./harness.mjs";
+import { fakeGlodaSearcherClass, fakeSandbox, loadExperiment } from "./harness.mjs";
 
 const ACCOUNTS = [
   { key: "account1", incomingServer: { rootFolder: { URI: "imap://me@example.com" } } },
 ];
+const FOLDER_URI = "imap://me@example.com/INBOX";
 
-/** The gloda module's pure helpers, with `accounts` as MailServices reports them. */
-function hooks({ accounts = ACCOUNTS, ...options } = {}) {
+/** How many rows `gloda.search` over-fetches for a default, unscoped query. */
+const RETRIEVE = 75;
+
+/** Values built inside the vm carry that realm's prototypes; strip them. */
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** `count` indexed messages, newest first, as the searcher hands them over. */
+function corpus(count, { folderUri = FOLDER_URI } = {}) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: 1000 + index,
+    headerMessageID: `<g${index}@example.invalid>`,
+    subject: `Item ${index}`,
+    date: new Date(1700000000000 - index * 60000),
+    folderURI: folderUri,
+    conversationID: 500,
+    folderMessage: null,
+    from: { value: `ada${index}@example.invalid`, contact: null },
+    to: [],
+    involves: [],
+  }));
+}
+
+/**
+ * The gloda module, loaded over a fixed index.
+ *
+ * `call` reaches a handler through the dispatch table rather than through
+ * `invoke`, so a failure arrives as the error gloda raised instead of the wire
+ * envelope core.js packs it into — that envelope is core.test.mjs's business.
+ */
+function experiment({ messages = [], accounts = ACCOUNTS, prefs = {}, modules = {} } = {}) {
   const globals = fakeSandbox({
-    ...options,
+    prefs: { "mailnews.database.global.indexer.enabled": true, ...prefs },
     modules: {
       "resource:///modules/MailServices.sys.mjs": { MailServices: { accounts: { accounts } } },
-      ...(options.modules || {}),
+      "resource:///modules/gloda/GlodaMsgSearcher.sys.mjs": {
+        GlodaMsgSearcher: fakeGlodaSearcherClass({ corpus: messages }),
+      },
+      ...modules,
     },
   });
-  return loadExperiment(globals, { modules: ["gloda"] }).TBX_TEST_HOOKS.gloda;
+  const ctx = loadExperiment(globals, { modules: ["gloda"] });
+  return {
+    gloda: ctx.TBX_TEST_HOOKS.gloda,
+    call: (method, params) => ctx.TBX_TEST_HOOKS.core.handlers[method](params || {}),
+  };
+}
+
+/** The gloda module's pure helpers, with `accounts` as MailServices reports them. */
+function hooks(options = {}) {
+  return experiment(options).gloda;
 }
 
 describe("isoDate", () => {
@@ -69,5 +112,102 @@ describe("folderMatcher", () => {
         return true;
       }
     );
+  });
+});
+
+describe("classifyTerms", () => {
+  it("separates the terms the index can match from the ones it throws away", () => {
+    const { classifyTerms } = hooks();
+
+    assert.deepEqual(plain(classifyTerms(["payments", "2.0"])), {
+      usable: ["payments"],
+      unmatchable: ["2.0"],
+    });
+  });
+
+  it("finds nothing usable in terms that tokenize to nothing", () => {
+    const { classifyTerms } = hooks();
+
+    assert.deepEqual(plain(classifyTerms(["2.0", "-"])).usable, []);
+  });
+
+  it("keeps CJK, which the tokenizer indexes one character at a time", () => {
+    const { classifyTerms } = hooks();
+
+    assert.deepEqual(plain(classifyTerms(["東京"])).usable, ["東京"]);
+  });
+});
+
+describe("gloda.search over unmatchable terms", () => {
+  it("runs the query and names the terms that cannot pull their weight", async () => {
+    const { call } = experiment({ messages: corpus(3) });
+
+    const result = plain(await call("gloda.search", { query: "payments 2.0" }));
+
+    assert.equal(result.matched, 3, "the query still ran");
+    assert.deepEqual(result.unmatchableTerms, ["2.0"]);
+  });
+
+  it("says nothing about terms when every one of them can match", async () => {
+    const { call } = experiment({ messages: corpus(3) });
+
+    const result = plain(await call("gloda.search", { query: "payments" }));
+
+    assert.equal(result.unmatchableTerms, undefined);
+  });
+
+  it("explains an empty result the unmatchable term caused", async () => {
+    const { call } = experiment();
+
+    const result = plain(await call("gloda.search", { query: "payments 2.0" }));
+
+    assert.equal(
+      result.note,
+      'The index cannot match "2.0" — it tokenizes into pieces shorter than three ' +
+        "characters, and every term has to match. Drop those words and search again, " +
+        "or use mail_search with a subject filter."
+    );
+  });
+
+  it("lets a disabled index keep the last word", async () => {
+    const { call } = experiment({
+      prefs: { "mailnews.database.global.indexer.enabled": false },
+    });
+
+    const result = plain(await call("gloda.search", { query: "payments 2.0" }));
+
+    assert.match(result.note, /global index is disabled/);
+  });
+
+  it("still refuses a query with no usable term at all", async () => {
+    const { call } = experiment({ messages: corpus(3) });
+
+    await assert.rejects(call("gloda.search", { query: "2.0" }), (ex) => {
+      assert.equal(ex.tbxKind, "usage");
+      assert.match(ex.message, /no searchable term/);
+      return true;
+    });
+  });
+});
+
+describe("gloda.search truncation", () => {
+  it("does not call a corpus that exactly fills the retrieval truncated", async () => {
+    const { call } = experiment({ messages: corpus(RETRIEVE) });
+
+    const result = plain(await call("gloda.search", { query: "payments" }));
+
+    assert.equal(result.truncated, false);
+    assert.equal(result.matched, RETRIEVE);
+    assert.equal(result.retrieved, RETRIEVE);
+  });
+
+  it("reports a deeper corpus as truncated without counting the probe row", async () => {
+    const { call } = experiment({ messages: corpus(RETRIEVE + 5) });
+
+    const result = plain(await call("gloda.search", { query: "payments", limit: 25 }));
+
+    assert.equal(result.truncated, true);
+    assert.equal(result.retrieved, RETRIEVE, "the probe row is not a considered row");
+    assert.equal(result.hits.length, 25);
   });
 });

--- a/tests/js/gloda.test.mjs
+++ b/tests/js/gloda.test.mjs
@@ -1,0 +1,73 @@
+/* Gloda — the global index, and the four ways a search of it came back empty.
+ *
+ * Every defect here was invisible in a unit test that built its own Date or its
+ * own folder id, and obvious against a real profile: gloda hands back objects
+ * from another realm, WebExtension folder ids look like URIs, and a term the
+ * tokenizer throws away still reaches the SQL and zeroes the query.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import vm from "node:vm";
+
+import { fakeSandbox, loadExperiment } from "./harness.mjs";
+
+const ACCOUNTS = [
+  { key: "account1", incomingServer: { rootFolder: { URI: "imap://me@example.com" } } },
+];
+
+/** The gloda module's pure helpers, with `accounts` as MailServices reports them. */
+function hooks({ accounts = ACCOUNTS, ...options } = {}) {
+  const globals = fakeSandbox({
+    ...options,
+    modules: {
+      "resource:///modules/MailServices.sys.mjs": { MailServices: { accounts: { accounts } } },
+      ...(options.modules || {}),
+    },
+  });
+  return loadExperiment(globals, { modules: ["gloda"] }).TBX_TEST_HOOKS.gloda;
+}
+
+describe("isoDate", () => {
+  it("dates a gloda hit whose Date was minted in another realm", () => {
+    const { isoDate } = hooks();
+
+    // `instanceof Date` is false for this one, which is why every hit was null.
+    assert.equal(isoDate(vm.runInNewContext("new Date(0)")), "1970-01-01T00:00:00.000Z");
+  });
+
+  it("still reads a raw PRTime, and nothing out of nothing", () => {
+    const { isoDate } = hooks();
+
+    assert.equal(isoDate(1000000), "1970-01-01T00:00:01.000Z");
+    assert.equal(isoDate(null), null);
+    assert.equal(isoDate(undefined), null);
+  });
+});
+
+describe("folderMatcher", () => {
+  it("matches a WebExtension folder id against the hit's own id", () => {
+    const matches = hooks().folderMatcher("account1://INBOX");
+
+    assert.equal(matches({ folderId: "account1://INBOX" }), true);
+    assert.equal(matches({ folderId: "account1://Sent" }), false);
+  });
+
+  it("matches a folder URI under an account's root against the hit's URI", () => {
+    const matches = hooks().folderMatcher("imap://me@example.com/INBOX");
+
+    assert.equal(matches({ folderUri: "imap://me@example.com/INBOX" }), true);
+    assert.equal(matches({ folderUri: "imap://me@example.com/Sent" }), false);
+  });
+
+  it("says so when the reference belongs to no account here", () => {
+    assert.throws(
+      () => hooks().folderMatcher("accountZZ://nope"),
+      (ex) => {
+        assert.equal(ex.tbxKind, "usage");
+        assert.match(ex.message, /accountZZ/);
+        return true;
+      }
+    );
+  });
+});

--- a/tests/js/gloda.test.mjs
+++ b/tests/js/gloda.test.mjs
@@ -211,3 +211,121 @@ describe("gloda.search truncation", () => {
     assert.equal(result.hits.length, 25);
   });
 });
+
+/** An identity as gloda models one: an address, optionally with a contact name. */
+function identity(name, address) {
+  return { value: address, contact: name ? { name } : null };
+}
+
+const ADA = identity("Ada", "ada@example.invalid");
+const BOB = identity("Bob", "bob@example.invalid");
+const CARA = identity(null, "cara@example.invalid");
+
+/** A gloda whose only query answers with `seed`. */
+function fakeGloda(seed) {
+  return {
+    newQuery() {
+      return {
+        headerMessageID() {
+          return this;
+        },
+        getCollection(listener) {
+          listener.onItemsAdded([seed]);
+          listener.onQueryCompleted();
+        },
+      };
+    },
+  };
+}
+
+/** The modules `gloda.conversation` reaches for, over one fixed thread. */
+function threadModules(messages) {
+  const conversation = {
+    id: 77,
+    subject: "Shipment",
+    oldestMessageDate: new Date(1700000000000),
+    newestMessageDate: new Date(1700000120000),
+    getMessagesCollection(listener) {
+      listener.onItemsAdded(messages);
+      listener.onQueryCompleted();
+    },
+  };
+  const seed = { ...messages[0], conversation };
+  return {
+    "resource:///modules/gloda/GlodaPublic.sys.mjs": { Gloda: fakeGloda(seed) },
+    "resource:///modules/gloda/GlodaConstants.sys.mjs": { GlodaConstants: { NOUN_MESSAGE: 5 } },
+  };
+}
+
+describe("gloda.conversation", () => {
+  it("names everyone who took part, once each, in the order they appear", async () => {
+    const [first, second, third] = corpus(3);
+    const messages = [
+      { ...first, date: new Date(1700000120000), involves: [ADA, BOB] },
+      { ...second, date: new Date(1700000060000), involves: [BOB, CARA] },
+      { ...third, date: new Date(1700000000000), involves: [ADA] },
+    ];
+    const { call } = experiment({ modules: threadModules(messages) });
+
+    const result = plain(await call("gloda.conversation", { headerMessageId: "<g0@x>" }));
+
+    assert.deepEqual(result.participants, [
+      "Ada <ada@example.invalid>",
+      "Bob <bob@example.invalid>",
+      "cara@example.invalid",
+    ]);
+    assert.equal(result.total, 3);
+    assert.deepEqual(
+      result.messages.map((message) => message.glodaId),
+      [1002, 1001, 1000],
+      "oldest first, which only works now that the hits carry dates"
+    );
+  });
+
+  it("falls back to the addresses it has when gloda indexed no participants", async () => {
+    const [only] = corpus(1);
+    const messages = [{ ...only, involves: [], from: ADA, to: [BOB] }];
+    const { call } = experiment({ modules: threadModules(messages) });
+
+    const result = plain(await call("gloda.conversation", { headerMessageId: "<g0@x>" }));
+
+    assert.deepEqual(result.participants, [
+      "Ada <ada@example.invalid>",
+      "Bob <bob@example.invalid>",
+    ]);
+  });
+});
+
+describe("gloda.stats", () => {
+  it("counts the indexed messages instead of giving up on the deadline", async () => {
+    const datastore = {
+      asyncConnection: {
+        createAsyncStatement: () => ({
+          executeAsync(handler) {
+            let served = false;
+            handler.handleResult({
+              getNextRow() {
+                if (served) {
+                  return null;
+                }
+                served = true;
+                return { getInt64: () => 2185 };
+              },
+            });
+            handler.handleCompletion();
+          },
+          finalize() {},
+        }),
+      },
+    };
+    const { call } = experiment({
+      modules: {
+        "resource:///modules/gloda/GlodaDatastore.sys.mjs": { GlodaDatastore: datastore },
+      },
+    });
+
+    const stats = plain(await call("gloda.stats"));
+
+    assert.equal(stats.indexedMessages, 2185);
+  });
+});

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -208,6 +208,8 @@ export function fakeBrowser({ pairing = null, manifestVersion = "9.9.9" } = {}) 
       readBridgeFile: async () => (typeof pairing === "function" ? pairing() : pairing),
       appInfo: async () => ({ name: "Thunderbird", version: "155.0" }),
       availableModules: async () => ({ loaded: [], methods: [], resolvable: [] }),
+      keepAlive: async () => ({ enabled: true, intervalMs: 20000, idleTimeoutMs: 30000 }),
+      grantOptionalPermission: async () => ({ alreadyHad: true, granted: true }),
       writeStatus: async (report) => {
         browser._written.push(report);
       },

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -212,6 +212,7 @@ export function fakeBrowser({ pairing = null, manifestVersion = "9.9.9" } = {}) 
       grantOptionalPermission: async () => ({ alreadyHad: true, granted: true }),
       writeStatus: async (report) => {
         browser._written.push(report);
+        return "<profile>/tbmcp-addon-status.json"; // the real one answers with the path
       },
     },
     storage: {

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -224,3 +224,99 @@ export function fakeBrowser({ pairing = null, manifestVersion = "9.9.9" } = {}) 
   };
   return browser;
 }
+
+/**
+ * The `browser.messages` half of the WebExtension API, over headers held in
+ * memory.
+ *
+ * Thunderbird answers `list` and `query` with a `MessageList`: one page of
+ * messages plus an `id` that is present only while further pages remain, walked
+ * with `continueList` and thrown away with `abortList`. Every paging bug this
+ * suite guards against lives in that shape, so the fake reproduces it exactly —
+ * including `returnMessageListId`, which replaces the first page with a bare id
+ * string. List ids are minted in order (`list-1`, `list-2`, …) so a test can say
+ * which walk it means.
+ *
+ * @param {object} folders  folder id -> its headers, in the order Thunderbird
+ *   would return them.
+ * @param {number} pageSize  page size for `list`.
+ * @param {number} queryPageSize  page size for `query`, unless the query names
+ *   one with `messagesPerPage`.
+ */
+export function fakeMessages({ folders = {}, pageSize = 10, queryPageSize = 100 } = {}) {
+  const lists = new Map();
+  const calls = [];
+  let sequence = 0;
+
+  /** Start a walk over `items` and hand back its id. */
+  function open(items, size) {
+    sequence += 1;
+    const id = `list-${sequence}`;
+    lists.set(id, { items, offset: 0, size: Math.max(1, size) });
+    return id;
+  }
+
+  /** The next page of a live list; the last one carries no id and closes it. */
+  function page(id) {
+    const list = lists.get(id);
+    const messages = list.items.slice(list.offset, list.offset + list.size);
+    list.offset += messages.length;
+    if (list.offset >= list.items.length) {
+      lists.delete(id);
+      return { messages };
+    }
+    return { id, messages };
+  }
+
+  /** The filters `messages.query` supports that these tests exercise. */
+  function matches(header, queryInfo, folderId) {
+    if (queryInfo.subject && !String(header.subject || "").includes(queryInfo.subject)) {
+      return false;
+    }
+    if (queryInfo.folderId) {
+      const wanted = Array.isArray(queryInfo.folderId) ? queryInfo.folderId : [queryInfo.folderId];
+      if (!wanted.includes(folderId)) {
+        return false;
+      }
+    }
+    // A folder id is "<accountId>://<path>", so the account is its prefix.
+    if (queryInfo.accountId && folderId.split(":/")[0] !== queryInfo.accountId) {
+      return false;
+    }
+    return true;
+  }
+
+  return {
+    calls,
+    async list(folderId, options) {
+      calls.push({ method: "list", args: [folderId, options] });
+      return page(open([...(folders[folderId] || [])], pageSize));
+    },
+    async query(queryInfo = {}) {
+      calls.push({ method: "query", args: [queryInfo] });
+      const hits = [];
+      for (const [folderId, headers] of Object.entries(folders)) {
+        for (const header of headers) {
+          if (matches(header, queryInfo, folderId)) {
+            hits.push(header);
+          }
+        }
+      }
+      const id = open(hits, queryInfo.messagesPerPage || queryPageSize);
+      // Thunderbird's schema: the flag "will change the return value of this
+      // function and return the messageListId directly".
+      return queryInfo.returnMessageListId ? id : page(id);
+    },
+    async continueList(id) {
+      calls.push({ method: "continueList", args: [id] });
+      if (!lists.has(id)) {
+        throw new Error("Unknown or expired list");
+      }
+      return page(id);
+    },
+    async abortList(id) {
+      calls.push({ method: "abortList", args: [id] });
+      lists.delete(id);
+    },
+  };
+}

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -320,3 +320,189 @@ export function fakeMessages({ folders = {}, pageSize = 10, queryPageSize = 100 
     },
   };
 }
+
+/* --------------------------------------------------------- the privileged half */
+
+/** Must match `src/tbmcp/addon_build.py::MODULE_MARKER`; the splice below is that
+ *  build step, reproduced so a test runs what ships. */
+const MODULE_MARKER = "/* ===TBX_MODULES=== (build_xpi.py splices experiment/modules/*.js here) */";
+
+/** The GlodaMsgSearcher URL, which more than one caller here needs to name. */
+const GLODA_SEARCHER_URL = "resource:///modules/gloda/GlodaMsgSearcher.sys.mjs";
+
+/**
+ * A gloda full-text searcher over a fixed corpus.
+ *
+ * Gloda is callback-driven: a query hands its collection listener the rows it
+ * found, then says it is done. `limit(n)` is the only knob the add-on turns, and
+ * the number of rows that come back for a given `n` is exactly what tells
+ * `gloda.search` whether the corpus was deeper than it looked — so the fake
+ * honours it to the row.
+ *
+ * @param {object[]} corpus  synthetic gloda messages, in relevance order.
+ * @param {number[]} scores  per-row scores; defaults to descending integers.
+ */
+export function fakeGlodaSearcherClass({ corpus = [], scores = null } = {}) {
+  return class FakeGlodaMsgSearcher {
+    constructor(listener, query, matchAll) {
+      this.listener = listener;
+      this.fulltextTerms = String(query || "")
+        .split(/\s+/)
+        .filter(Boolean);
+      this.matchAll = matchAll;
+      this.scores = scores || corpus.map((_message, index) => corpus.length - index);
+      this.collection = null;
+      this.query = null;
+    }
+
+    buildFulltextQuery() {
+      const searcher = this;
+      return {
+        limit(n) {
+          this.n = n;
+        },
+        getCollection(collectionListener) {
+          const rows = corpus.slice(0, this.n === undefined ? corpus.length : this.n);
+          searcher.retrieved = rows.length;
+          collectionListener.onItemsAdded(rows);
+          collectionListener.onQueryCompleted();
+          return { items: rows };
+        },
+      };
+    }
+  };
+}
+
+/**
+ * The globals Thunderbird pre-injects into the ext-*.js sandbox, faked.
+ *
+ * Deliberately missing: `setTimeout` and every other DOM global. The privileged
+ * half runs in a plain system-principal sandbox with none of them, and code that
+ * reaches for one has to fail here the way it fails in Thunderbird.
+ *
+ * @param {object} modules  resource URL -> its exports, merged over the defaults;
+ *   an unnamed URL imports as `{}`. One URL always answers with one object, so a
+ *   test can inspect what the code under test did to it.
+ * @param {object} prefs  preference name -> value, for `Services.prefs`.
+ */
+export function fakeSandbox({ modules = {}, prefs = {} } = {}) {
+  const timer = {
+    armed: [],
+    cleared: [],
+    setTimeout(fn, ms, ...args) {
+      const id = setTimeout(fn, ms, ...args);
+      timer.armed.push(id);
+      return id;
+    },
+    clearTimeout(id) {
+      timer.cleared.push(id);
+      clearTimeout(id);
+    },
+  };
+
+  const records = [];
+  const record =
+    (level) =>
+    (...args) =>
+      records.push({ level, text: args.map(String).join(" ") });
+
+  const known = {
+    "resource://gre/modules/Timer.sys.mjs": timer,
+    "resource://gre/modules/ExtensionUtils.sys.mjs": {
+      ExtensionError: class ExtensionError extends Error {},
+    },
+    "resource:///modules/MailServices.sys.mjs": {
+      MailServices: { accounts: { accounts: [], allIdentities: [] } },
+    },
+    [GLODA_SEARCHER_URL]: { GlodaMsgSearcher: fakeGlodaSearcherClass() },
+    ...modules,
+  };
+  const unknown = new Map();
+
+  return {
+    ChromeUtils: {
+      importESModule(url) {
+        if (known[url]) {
+          return known[url];
+        }
+        if (!unknown.has(url)) {
+          unknown.set(url, {});
+        }
+        return unknown.get(url);
+      },
+    },
+    Services: {
+      prefs: {
+        getBoolPref: (name, fallback = false) =>
+          name in prefs ? Boolean(prefs[name]) : fallback,
+        getIntPref: (name, fallback = 0) => (name in prefs ? Number(prefs[name]) : fallback),
+      },
+      appinfo: {
+        name: "Thunderbird",
+        version: "155.0",
+        appBuildID: "20260101000000",
+        platformVersion: "155.0",
+        OS: "WINNT",
+      },
+      dirsvc: { get: (key) => ({ path: `/fake/${key}` }) },
+      locale: { appLocaleAsBCP47: "en-US" },
+    },
+    Cc: {},
+    Ci: {},
+    Cu: {},
+    Cr: {},
+    IOUtils: {
+      exists: async () => false,
+      readJSON: async () => null,
+      writeJSON: async () => {},
+      write: async () => {},
+    },
+    PathUtils: { join: (...parts) => parts.join("/") },
+    ExtensionAPI: class ExtensionAPI {},
+    console: {
+      records,
+      debug: record("debug"),
+      info: record("info"),
+      log: record("log"),
+      warn: record("warn"),
+      error: record("error"),
+    },
+    // Block-scoped helpers publish themselves here; in Thunderbird it is undefined
+    // and the publishing statement does nothing.
+    TBX_TEST_HOOKS: {},
+  };
+}
+
+/**
+ * Evaluate the privileged half — core.js with `modules` spliced in — in one context.
+ *
+ * The splice is the build step, not a convenience: core.js's `H`, `mod`,
+ * `TBX_MODULES` and `MODULE_URLS` are top-level `const`s, so a module loaded as a
+ * separate script would not see any of them. `this.tbx = class …` at the top level
+ * of core.js puts the API class on the context.
+ *
+ * @param {object} globals  usually `fakeSandbox()`, possibly with overrides.
+ * @param {string[]} modules  base names under `addon/experiment/modules/`.
+ * @returns {object} the context, with the API class at `ctx.tbx`.
+ */
+export function loadExperiment(globals = {}, { modules = [] } = {}) {
+  const experiment = path.join(ROOT, "addon", "experiment");
+  const core = fs.readFileSync(path.join(experiment, "core.js"), "utf8");
+  if (!core.includes(MODULE_MARKER)) {
+    throw new Error("experiment/core.js has no ===TBX_MODULES=== marker");
+  }
+  const chunks = modules.map((name) => {
+    const body = fs.readFileSync(path.join(experiment, "modules", `${name}.js`), "utf8");
+    return (
+      "/* ---------------------------------------------------------------\n" +
+      ` * experiment/modules/${name}.js\n` +
+      " * --------------------------------------------------------------- */\n" +
+      `${body.trimEnd()}\n`
+    );
+  });
+  const context = vm.createContext({ ...globals });
+  vm.runInContext(core.replace(MODULE_MARKER, chunks.join("\n")), context, {
+    filename: "experiment/implementation.js",
+  });
+  return context;
+}

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -27,8 +27,20 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", ".
  *   properties.
  */
 export function loadScript(relPath, globals = {}) {
+  return runInContext(vm.createContext({ ...globals }), relPath);
+}
+
+/**
+ * Evaluate `addon/<relPath>` in a context another script already ran in.
+ *
+ * Thunderbird loads every background script into one page scope, so a script
+ * that reads a `var` another one declared has to be tested that way — passing it
+ * in as a global would hide a load-order mistake.
+ *
+ * @returns {object} the same context, now carrying this script's top-level `var`s.
+ */
+export function runInContext(context, relPath) {
   const source = fs.readFileSync(path.join(ROOT, "addon", relPath), "utf8");
-  const context = vm.createContext({ ...globals });
   vm.runInContext(source, context, { filename: relPath });
   return context;
 }

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -351,10 +351,16 @@ const GLODA_SEARCHER_URL = "resource:///modules/gloda/GlodaMsgSearcher.sys.mjs";
  * `gloda.search` whether the corpus was deeper than it looked — so the fake
  * honours it to the row.
  *
+ * The searcher is its own collection listener: it scores each row as it arrives
+ * and passes it to whatever listener the caller hung on it. That relay is the
+ * part `gloda.search` depends on, so the fake keeps it.
+ *
  * @param {object[]} corpus  synthetic gloda messages, in relevance order.
  * @param {number[]} scores  per-row scores; defaults to descending integers.
  */
 export function fakeGlodaSearcherClass({ corpus = [], scores = null } = {}) {
+  const scoreFor = (index) => (scores ? scores[index] : corpus.length - index);
+
   return class FakeGlodaMsgSearcher {
     constructor(listener, query, matchAll) {
       this.listener = listener;
@@ -362,20 +368,33 @@ export function fakeGlodaSearcherClass({ corpus = [], scores = null } = {}) {
         .split(/\s+/)
         .filter(Boolean);
       this.matchAll = matchAll;
-      this.scores = scores || corpus.map((_message, index) => corpus.length - index);
+      this.scores = [];
       this.collection = null;
       this.query = null;
     }
 
+    onItemsAdded(items) {
+      for (const item of items) {
+        this.scores.push(scoreFor(corpus.indexOf(item)));
+      }
+      this.listener.onItemsAdded(items);
+    }
+
+    onItemsModified() {}
+
+    onItemsRemoved() {}
+
+    onQueryCompleted() {
+      this.listener.onQueryCompleted();
+    }
+
     buildFulltextQuery() {
-      const searcher = this;
       return {
-        limit(n) {
-          this.n = n;
+        limit(rows) {
+          this.rows = rows;
         },
         getCollection(collectionListener) {
-          const rows = corpus.slice(0, this.n === undefined ? corpus.length : this.n);
-          searcher.retrieved = rows.length;
+          const rows = corpus.slice(0, this.rows === undefined ? corpus.length : this.rows);
           collectionListener.onItemsAdded(rows);
           collectionListener.onQueryCompleted();
           return { items: rows };

--- a/tests/js/harness.mjs
+++ b/tests/js/harness.mjs
@@ -1,0 +1,223 @@
+/* Runs an add-on background script in a sandbox, with fakes for everything it
+ * talks to.
+ *
+ * The background scripts are plain classic scripts: no imports, no exports, each
+ * one a top-level `var` holding an object. Thunderbird loads them into one shared
+ * page scope. `node:vm` reproduces exactly that — a fresh global object per test
+ * whose properties are the globals we hand it — so the add-on source can be tested
+ * as it ships, with no build step and no test-only branches in it.
+ */
+
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import vm from "node:vm";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+/**
+ * Evaluate `addon/<relPath>` in a new context.
+ *
+ * @param {string} relPath  repo-relative to `addon/`, e.g. "background/log.js".
+ * @param {object} globals  what the script may see. Standard JavaScript built-ins
+ *   come with the context; anything the browser or Node supplies (`console`,
+ *   `setTimeout`, `TextEncoder`, `btoa`, `browser`, the other `tbx*` scripts) does
+ *   not, so pass what the script under test uses.
+ * @returns {object} the context, on which the script's top-level `var`s are
+ *   properties.
+ */
+export function loadScript(relPath, globals = {}) {
+  const source = fs.readFileSync(path.join(ROOT, "addon", relPath), "utf8");
+  const context = vm.createContext({ ...globals });
+  vm.runInContext(source, context, { filename: relPath });
+  return context;
+}
+
+/** A tbxLog that keeps what it was told instead of printing it. */
+export function fakeLog() {
+  const records = [];
+  const record =
+    (level) =>
+    (...args) =>
+      records.push({ level, text: args.map(String).join(" ") });
+  return {
+    init: async () => {},
+    setVerbose() {},
+    isVerbose: false,
+    debug: record("debug"),
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+    records,
+  };
+}
+
+/**
+ * Timers a test drives by hand.
+ *
+ * The transport is almost entirely timeouts, so real ones would make its tests
+ * both slow and flaky. `advance` fires what is due in order and yields to the
+ * microtask queue after each one, so an `async` handler is finished before the
+ * next timer runs. `advance(0)` is therefore also the way to settle pending
+ * promises without moving the clock.
+ */
+export function fakeClock() {
+  const FUSE = 10000; // a repeating timer with a zero delay would never end
+  let timers = [];
+  let sequence = 0;
+  let now = 0;
+
+  const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+  function arm(fn, delay, repeat, args) {
+    const timer = {
+      id: (sequence += 1),
+      time: now + Math.max(0, Number(delay) || 0),
+      repeat,
+      fn,
+      args,
+    };
+    timers.push(timer);
+    return timer.id;
+  }
+
+  /** The next timer at or before `target`; ties go to whichever was armed first. */
+  function due(target) {
+    let best = null;
+    for (const timer of timers) {
+      if (timer.time > target) {
+        continue;
+      }
+      if (!best || timer.time < best.time || (timer.time === best.time && timer.id < best.id)) {
+        best = timer;
+      }
+    }
+    return best;
+  }
+
+  return {
+    setTimeout: (fn, delay, ...args) => arm(fn, delay, null, args),
+    setInterval: (fn, delay, ...args) => arm(fn, delay, Math.max(1, Number(delay) || 1), args),
+    clearTimeout: (id) => {
+      timers = timers.filter((timer) => timer.id !== id);
+    },
+    clearInterval: (id) => {
+      timers = timers.filter((timer) => timer.id !== id);
+    },
+    now: () => now,
+    async advance(ms) {
+      const target = now + Math.max(0, ms);
+      for (let fired = 0; ; fired += 1) {
+        const timer = due(target);
+        if (!timer) {
+          break;
+        }
+        if (fired >= FUSE) {
+          throw new Error(`fakeClock fired ${FUSE} timers without reaching ${target}ms`);
+        }
+        now = timer.time;
+        if (timer.repeat === null) {
+          timers = timers.filter((other) => other !== timer);
+        } else {
+          timer.time = now + timer.repeat;
+        }
+        timer.fn(...timer.args);
+        await settle();
+      }
+      now = target;
+      await settle();
+    },
+  };
+}
+
+/**
+ * A WebSocket the test plays the daemon on.
+ *
+ * `open`, `receive` and `serverClose` are the daemon's side; `send`, `close` and
+ * the `readyState` are the add-on's, recorded for assertions.
+ */
+export function fakeWebSocketClass() {
+  class FakeWebSocket {
+    constructor(url) {
+      this.url = url;
+      this.readyState = FakeWebSocket.CONNECTING;
+      this.sent = [];
+      this.closeCalls = [];
+      this.onopen = null;
+      this.onmessage = null;
+      this.onerror = null;
+      this.onclose = null;
+      FakeWebSocket.instances.push(this);
+    }
+
+    send(data) {
+      this.sent.push(JSON.parse(data));
+    }
+
+    close(code, reason) {
+      this.closeCalls.push({ code, reason });
+      this.serverClose(code, reason);
+    }
+
+    /** The daemon completed the HTTP upgrade. */
+    open() {
+      this.readyState = FakeWebSocket.OPEN;
+      if (this.onopen) {
+        this.onopen();
+      }
+    }
+
+    /** The daemon sent a frame. */
+    receive(message) {
+      if (this.onmessage) {
+        this.onmessage({ data: JSON.stringify(message) });
+      }
+    }
+
+    /** The connection ended, from either side. */
+    serverClose(code, reason) {
+      this.readyState = FakeWebSocket.CLOSED;
+      if (this.onclose) {
+        this.onclose({ code, reason });
+      }
+    }
+  }
+
+  FakeWebSocket.CONNECTING = 0;
+  FakeWebSocket.OPEN = 1;
+  FakeWebSocket.CLOSING = 2;
+  FakeWebSocket.CLOSED = 3;
+  FakeWebSocket.instances = [];
+  return FakeWebSocket;
+}
+
+/**
+ * The `browser` global, answering only what the background scripts ask for.
+ *
+ * @param {object|Function} pairing  what `tbx.readBridgeFile()` resolves to; a
+ *   function is called per read, so a test can decide when the read finishes.
+ */
+export function fakeBrowser({ pairing = null, manifestVersion = "9.9.9" } = {}) {
+  const browser = {
+    _written: [],
+    runtime: {
+      getManifest: () => ({ version: manifestVersion }),
+      onSuspend: { addListener() {} },
+    },
+    tbx: {
+      readBridgeFile: async () => (typeof pairing === "function" ? pairing() : pairing),
+      appInfo: async () => ({ name: "Thunderbird", version: "155.0" }),
+      availableModules: async () => ({ loaded: [], methods: [], resolvable: [] }),
+      writeStatus: async (report) => {
+        browser._written.push(report);
+      },
+    },
+    storage: {
+      local: {
+        get: async () => ({}),
+        set: async () => {},
+      },
+    },
+  };
+  return browser;
+}

--- a/tests/js/harness.test.mjs
+++ b/tests/js/harness.test.mjs
@@ -13,7 +13,9 @@ import {
   fakeClock,
   fakeLog,
   fakeMessages,
+  fakeSandbox,
   fakeWebSocketClass,
+  loadExperiment,
   loadScript,
 } from "./harness.mjs";
 
@@ -188,5 +190,55 @@ describe("fakeMessages", () => {
       messages.calls.map((call) => call.method),
       ["list", "abortList", "continueList"]
     );
+  });
+});
+
+describe("fakeSandbox", () => {
+  it("injects what the ext-*.js sandbox injects, and no DOM timers", () => {
+    const globals = fakeSandbox();
+
+    assert.equal(globals.setTimeout, undefined, "the privileged sandbox has no DOM timers");
+    const timer = globals.ChromeUtils.importESModule("resource://gre/modules/Timer.sys.mjs");
+    assert.equal(typeof timer.setTimeout, "function");
+    assert.equal(
+      globals.ChromeUtils.importESModule("resource://gre/modules/Timer.sys.mjs"),
+      timer,
+      "one URL answers with one object, so a test can watch what the code did to it"
+    );
+    assert.deepEqual(
+      { ...globals.ChromeUtils.importESModule("resource://gre/modules/Unheard.sys.mjs") },
+      {},
+      "an unknown module imports as empty rather than throwing"
+    );
+  });
+
+  it("lets a test replace one module's exports", () => {
+    const globals = fakeSandbox({
+      modules: { "resource:///modules/MailServices.sys.mjs": { MailServices: { accounts: 7 } } },
+    });
+
+    const services = globals.ChromeUtils.importESModule("resource:///modules/MailServices.sys.mjs");
+    assert.equal(services.MailServices.accounts, 7);
+  });
+});
+
+describe("loadExperiment", () => {
+  it("splices the named modules into core.js and exposes the API class", async () => {
+    const ctx = loadExperiment(fakeSandbox(), { modules: ["gloda"] });
+
+    const api = new ctx.tbx().getAPI({ extension: {} }).tbx;
+    const report = await api.availableModules();
+
+    assert.deepEqual([...report.loaded], ["gloda"], "the module announced itself");
+    assert.ok(report.methods.includes("gloda.search"), "its handlers reached the dispatch table");
+  });
+
+  it("leaves core.js alone when no module is named", async () => {
+    const ctx = loadExperiment(fakeSandbox(), { modules: [] });
+
+    const report = await new ctx.tbx().getAPI({ extension: {} }).tbx.availableModules();
+
+    assert.deepEqual([...report.loaded], []);
+    assert.deepEqual([...report.methods], []);
   });
 });

--- a/tests/js/harness.test.mjs
+++ b/tests/js/harness.test.mjs
@@ -1,0 +1,121 @@
+/* The harness testing itself.
+ *
+ * If loadScript ever stops exposing an add-on script's top-level `var`s, every
+ * other test in this directory fails in a way that looks like a bug in the
+ * add-on. This one test says otherwise.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { fakeBrowser, fakeClock, fakeLog, fakeWebSocketClass, loadScript } from "./harness.mjs";
+
+describe("loadScript", () => {
+  it("exposes a script's top-level var and runs it against the given globals", () => {
+    const calls = [];
+    const ctx = loadScript("background/log.js", {
+      browser: fakeBrowser(),
+      console: { info: (...args) => calls.push(args) },
+    });
+
+    ctx.tbxLog.info("x");
+
+    assert.deepEqual(calls, [["[tbmcp]", "x"]]);
+  });
+});
+
+describe("fakeLog", () => {
+  it("records every level as flat text", () => {
+    const log = fakeLog();
+
+    log.warn("port", 4711, "is busy");
+
+    assert.deepEqual(log.records, [{ level: "warn", text: "port 4711 is busy" }]);
+  });
+});
+
+describe("fakeClock", () => {
+  it("fires due timers in order and lets async handlers settle", async () => {
+    const clock = fakeClock();
+    const order = [];
+    clock.setTimeout(async () => {
+      order.push("late");
+    }, 20);
+    clock.setTimeout(() => order.push("early"), 10);
+
+    await clock.advance(9);
+    assert.deepEqual(order, []);
+
+    await clock.advance(11);
+    assert.deepEqual(order, ["early", "late"]);
+    assert.equal(clock.now(), 20);
+  });
+
+  it("forgets a cleared timer and repeats an interval", async () => {
+    const clock = fakeClock();
+    const ticks = [];
+    const cancelled = clock.setTimeout(() => ticks.push("never"), 5);
+    clock.clearTimeout(cancelled);
+    const interval = clock.setInterval(() => ticks.push("tick"), 10);
+
+    await clock.advance(25);
+    clock.clearInterval(interval);
+    await clock.advance(25);
+
+    assert.deepEqual(ticks, ["tick", "tick"]);
+  });
+});
+
+describe("fakeWebSocketClass", () => {
+  it("records what the add-on sends and replays what the daemon does", () => {
+    const WebSocket = fakeWebSocketClass();
+    const events = [];
+    const ws = new WebSocket("ws://127.0.0.1:1/tbmcp");
+    ws.onopen = () => events.push("open");
+    ws.onmessage = (event) => events.push(JSON.parse(event.data).t);
+    ws.onclose = (event) => events.push(`close ${event.code} ${event.reason}`);
+
+    assert.equal(WebSocket.instances[0], ws);
+    assert.equal(ws.readyState, WebSocket.CONNECTING);
+    ws.open();
+    assert.equal(ws.readyState, WebSocket.OPEN);
+    ws.send(JSON.stringify({ t: "hello" }));
+    ws.receive({ t: "welcome" });
+    ws.serverClose(1006, "gone");
+
+    assert.deepEqual(ws.sent, [{ t: "hello" }]);
+    assert.deepEqual(events, ["open", "welcome", "close 1006 gone"]);
+    assert.equal(ws.readyState, WebSocket.CLOSED);
+  });
+
+  it("records close() and reports it back through onclose", () => {
+    const WebSocket = fakeWebSocketClass();
+    const seen = [];
+    const ws = new WebSocket("ws://127.0.0.1:1/tbmcp");
+    ws.onclose = (event) => seen.push(event.code);
+
+    ws.close(4000, "no welcome");
+
+    assert.deepEqual(ws.closeCalls, [{ code: 4000, reason: "no welcome" }]);
+    assert.deepEqual(seen, [4000]);
+  });
+});
+
+describe("fakeBrowser", () => {
+  it("answers the calls the add-on makes at startup", async () => {
+    const browser = fakeBrowser({ pairing: { version: 1, port: 4711, token: "t" } });
+
+    assert.equal(browser.runtime.getManifest().version, "9.9.9");
+    assert.deepEqual(await browser.tbx.readBridgeFile(), { version: 1, port: 4711, token: "t" });
+    await browser.tbx.writeStatus({ ok: true });
+    assert.deepEqual(browser._written, [{ ok: true }]);
+  });
+
+  it("calls a pairing function so a test can control when the read finishes", async () => {
+    let resolve;
+    const browser = fakeBrowser({ pairing: () => new Promise((r) => (resolve = r)) });
+    const pending = browser.tbx.readBridgeFile();
+    resolve({ version: 1, port: 1, token: "t" });
+    assert.equal((await pending).port, 1);
+  });
+});

--- a/tests/js/harness.test.mjs
+++ b/tests/js/harness.test.mjs
@@ -8,7 +8,14 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { fakeBrowser, fakeClock, fakeLog, fakeWebSocketClass, loadScript } from "./harness.mjs";
+import {
+  fakeBrowser,
+  fakeClock,
+  fakeLog,
+  fakeMessages,
+  fakeWebSocketClass,
+  loadScript,
+} from "./harness.mjs";
 
 describe("loadScript", () => {
   it("exposes a script's top-level var and runs it against the given globals", () => {
@@ -117,5 +124,69 @@ describe("fakeBrowser", () => {
     const pending = browser.tbx.readBridgeFile();
     resolve({ version: 1, port: 1, token: "t" });
     assert.equal((await pending).port, 1);
+  });
+});
+
+describe("fakeMessages", () => {
+  const FOLDER = "account1://Inbox";
+
+  /** `count` headers, newest first, the way Thunderbird hands them over. */
+  function sample(count, folderId = FOLDER) {
+    return Array.from({ length: count }, (_, index) => ({
+      id: 100 + index,
+      headerMessageId: `<m${index}@example.invalid>`,
+      subject: `Re: item ${index}`,
+      author: "Ada <ada@example.invalid>",
+      recipients: ["bob@example.invalid"],
+      date: 1700000000000 - index * 60000,
+      read: false,
+      flagged: false,
+      junk: false,
+      tags: [],
+      size: 1024,
+      folder: { id: folderId, path: "/Inbox" },
+    }));
+  }
+
+  it("pages a folder and leaves the id off the last page", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(12) }, pageSize: 10 });
+
+    const first = await messages.list(FOLDER, { sortType: "date", sortOrder: "descending" });
+    assert.equal(first.messages.length, 10);
+    assert.ok(first.id, "more pages remain, so the list stays open");
+
+    const last = await messages.continueList(first.id);
+    assert.equal(last.messages.length, 2);
+    assert.equal(last.id, undefined, "the last page carries no id");
+
+    await assert.rejects(messages.continueList(first.id), /Unknown or expired list/);
+  });
+
+  it("answers a query with a bare list id when the query asks for one", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(12) }, queryPageSize: 10 });
+
+    const id = await messages.query({ subject: "Re", returnMessageListId: true });
+    assert.equal(typeof id, "string", "returnMessageListId replaces the page with its id");
+
+    const first = await messages.continueList(id);
+    assert.equal(first.messages.length, 10, "the id is still on its first page");
+    assert.deepEqual(
+      (await messages.query({ subject: "item 11" })).messages.map((m) => m.id),
+      [111],
+      "subject is a case-sensitive substring match"
+    );
+  });
+
+  it("forgets an aborted list and records every call", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(12) }, pageSize: 10 });
+
+    const first = await messages.list(FOLDER, {});
+    await messages.abortList(first.id);
+
+    await assert.rejects(messages.continueList(first.id), /Unknown or expired list/);
+    assert.deepEqual(
+      messages.calls.map((call) => call.method),
+      ["list", "abortList", "continueList"]
+    );
   });
 });

--- a/tests/js/messages.test.mjs
+++ b/tests/js/messages.test.mjs
@@ -1,0 +1,114 @@
+/* messages.query and messages.list, driven the way the daemon drives them.
+ *
+ * Both walk Thunderbird's MessageList, and both had a defect that only a real
+ * mailbox showed: a query that answered with a list id instead of messages, and
+ * a cursor that resumed on the page *after* the one it stopped in, silently
+ * dropping everything it had not returned. The tests here are those two walks.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { fakeBrowser, fakeLog, fakeMessages, loadScript } from "./harness.mjs";
+
+const FOLDER = "account1://Inbox";
+
+/** `count` headers, newest first, shaped the way Thunderbird hands them over. */
+function sample(count, folderId = FOLDER) {
+  return Array.from({ length: count }, (_, index) => ({
+    id: 100 + index,
+    headerMessageId: `<m${index}@example.invalid>`,
+    subject: `Re: item ${index}`,
+    author: "Ada <ada@example.invalid>",
+    recipients: ["bob@example.invalid"],
+    date: 1700000000000 - index * 60000,
+    read: false,
+    flagged: false,
+    junk: false,
+    tags: [],
+    size: 1024,
+    folder: { id: folderId, path: "/Inbox" },
+  }));
+}
+
+/**
+ * Load the handler module and hand back what it defined.
+ *
+ * The real registry.js supplies tbxError and tbxUtil so failures carry the same
+ * shape the daemon sees; tbxRegistry is faked only to catch the definitions.
+ */
+function loadHandlers(messages, browser = fakeBrowser()) {
+  const registry = loadScript("background/registry.js");
+  const handlers = new Map();
+  browser.messages = messages;
+  loadScript("background/handlers/messages.js", {
+    browser,
+    tbxLog: fakeLog(),
+    tbxError: registry.tbxError,
+    tbxUtil: registry.tbxUtil,
+    tbxRegistry: {
+      define(method, fn) {
+        handlers.set(method, fn);
+      },
+    },
+  });
+  return handlers;
+}
+
+/** Values built inside the vm carry that realm's prototypes; strip them. */
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+/** The message ids of one page. */
+function ids(result) {
+  return plain(result.messages).map((message) => message.id);
+}
+
+/** Errors cross the vm realm boundary, so match on the wire fields, not instanceof. */
+function usageError(pattern) {
+  return (ex) => {
+    assert.equal(ex.tbxKind, "usage", `wrong error kind: ${ex.message}`);
+    assert.match(ex.message, pattern);
+    return true;
+  };
+}
+
+describe("messages.query", () => {
+  it("answers with the matching headers, not with a list id", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    const query = loadHandlers(messages).get("messages.query");
+
+    const result = await query({ query: { subject: "Re" }, limit: 5 });
+
+    assert.equal(result.messages.length, 5);
+    assert.deepEqual(ids(result), [100, 101, 102, 103, 104]);
+    assert.equal(result.messages[0].subject, "Re: item 0");
+    assert.ok(result.cursor, "25 matches are left, so there has to be a cursor");
+  });
+
+  it("asks for a page of its own size rather than a bare list id", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    const query = loadHandlers(messages).get("messages.query");
+
+    await query({ query: { subject: "Re" }, limit: 5 });
+
+    const queryInfo = messages.calls[0].args[0];
+    assert.equal(queryInfo.returnMessageListId, undefined);
+    assert.equal(queryInfo.messagesPerPage, 5);
+  });
+
+  it("resolves a bare list id, for a build that insists on answering with one", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    // Same fake, forced into the shape returnMessageListId produces.
+    const stubborn = {
+      ...messages,
+      query: (queryInfo) => messages.query({ ...queryInfo, returnMessageListId: true }),
+    };
+    const query = loadHandlers(stubborn).get("messages.query");
+
+    const result = await query({ query: { subject: "Re" }, limit: 5 });
+
+    assert.deepEqual(ids(result), [100, 101, 102, 103, 104]);
+  });
+});

--- a/tests/js/messages.test.mjs
+++ b/tests/js/messages.test.mjs
@@ -225,7 +225,11 @@ describe("paging", () => {
 
     assert.deepEqual(walked.pages, [5, 5, 2]);
     assert.equal(walked.cursors.at(-1), null);
-    assert.match(walked.cursors[0], /^tbx:\d+$/, "a part-read page needs a cursor of ours");
+    assert.match(
+      walked.cursors[0],
+      /^tbx:[^:]+:\d+$/,
+      "a part-read page needs a cursor of ours, naming this load"
+    );
     assert.match(
       walked.cursors[1],
       /^list-/,
@@ -253,6 +257,35 @@ describe("paging", () => {
     );
     const newest = await list({ folderId: FOLDER, limit: 3, cursor: cursors.at(-1) });
     assert.equal(newest.messages.length, 3, "the newest walk survived the eviction");
+  });
+
+  it("refuses a cursor minted by an earlier load of the script", async () => {
+    const folders = { [FOLDER]: sample(30) };
+    const first = loadHandlers(fakeMessages({ folders, pageSize: 10 }));
+    const second = loadHandlers(fakeMessages({ folders, pageSize: 10 }));
+    const stale = (await first.get("messages.list")({ folderId: FOLDER, limit: 3 })).cursor;
+    const fresh = (await second.get("messages.list")({ folderId: FOLDER, limit: 3 })).cursor;
+
+    assert.notEqual(stale, fresh, "two loads must not mint the same cursor");
+    await assert.rejects(
+      () => second.get("messages.list")({ folderId: FOLDER, limit: 3, cursor: stale }),
+      usageError(/cursor/)
+    );
+  });
+
+  it("refuses a cursor of ours from a foreign load instead of trying it", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, pageSize: 10 });
+    const list = loadHandlers(messages).get("messages.list");
+
+    await assert.rejects(
+      () => list({ folderId: FOLDER, limit: 3, cursor: "tbx:zzzz:1" }),
+      usageError(/cursor/)
+    );
+    assert.deepEqual(
+      messages.calls.filter((call) => call.method === "continueList"),
+      [],
+      "a cursor of ours must never be handed to Thunderbird"
+    );
   });
 
   it("says a raw Thunderbird cursor has expired", async () => {

--- a/tests/js/messages.test.mjs
+++ b/tests/js/messages.test.mjs
@@ -9,7 +9,7 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
 
-import { fakeBrowser, fakeLog, fakeMessages, loadScript } from "./harness.mjs";
+import { fakeBrowser, fakeMessages, loadScript } from "./harness.mjs";
 
 const FOLDER = "account1://Inbox";
 
@@ -37,13 +37,13 @@ function sample(count, folderId = FOLDER) {
  * The real registry.js supplies tbxError and tbxUtil so failures carry the same
  * shape the daemon sees; tbxRegistry is faked only to catch the definitions.
  */
-function loadHandlers(messages, browser = fakeBrowser()) {
+function loadHandlers(messages) {
   const registry = loadScript("background/registry.js");
+  const browser = fakeBrowser();
   const handlers = new Map();
   browser.messages = messages;
   loadScript("background/handlers/messages.js", {
     browser,
-    tbxLog: fakeLog(),
     tbxError: registry.tbxError,
     tbxUtil: registry.tbxUtil,
     tbxRegistry: {
@@ -168,5 +168,100 @@ describe("messages.query", () => {
 
     assert.equal(next.messages.length, 5, "the walk carried on");
     assert.equal(next.scope, undefined, "the scope belongs to the first page only");
+  });
+});
+
+describe("paging", () => {
+  /** Walk a handler with its own cursors until it says there is nothing left. */
+  async function walk(handler, params) {
+    const seen = [];
+    const pages = [];
+    const cursors = [];
+    for (let guard = 0, cursor = null; guard < 200; guard += 1) {
+      const result = await handler({ ...params, cursor });
+      pages.push(result.messages.length);
+      seen.push(...ids(result));
+      cursors.push(result.cursor);
+      cursor = result.cursor;
+      if (!cursor) {
+        return { seen, pages, cursors };
+      }
+    }
+    throw new Error("the walk never ran out of cursors");
+  }
+
+  it("walks a folder without gaps or duplicates, whatever the limit", async () => {
+    for (const limit of [1, 3, 7, 25]) {
+      const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, pageSize: 10 });
+      const list = loadHandlers(messages).get("messages.list");
+      const whole = await list({ folderId: FOLDER, limit: 30 });
+
+      const walked = await walk(list, { folderId: FOLDER, limit });
+
+      assert.equal(walked.seen.length, 30, `limit ${limit} lost messages`);
+      assert.deepEqual(walked.seen, ids(whole), `limit ${limit} walked out of order`);
+    }
+  });
+
+  it("walks a query without gaps or duplicates, whatever the limit", async () => {
+    for (const limit of [1, 3, 7, 25]) {
+      const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+      const query = loadHandlers(messages).get("messages.query");
+      const params = { query: { subject: "Re: item" } };
+      const whole = await query({ ...params, limit: 30 });
+
+      const walked = await walk(query, { ...params, limit });
+
+      assert.equal(walked.seen.length, 30, `limit ${limit} lost messages`);
+      assert.deepEqual(walked.seen, ids(whole), `limit ${limit} walked out of order`);
+    }
+  });
+
+  it("returns the short last page and then stops", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(12) }, pageSize: 10 });
+    const list = loadHandlers(messages).get("messages.list");
+
+    const walked = await walk(list, { folderId: FOLDER, limit: 5 });
+
+    assert.deepEqual(walked.pages, [5, 5, 2]);
+    assert.equal(walked.cursors.at(-1), null);
+    assert.match(walked.cursors[0], /^tbx:\d+$/, "a part-read page needs a cursor of ours");
+    assert.match(
+      walked.cursors[1],
+      /^list-/,
+      "a page that ended on the limit leaves nothing over, so the list id will do"
+    );
+  });
+
+  it("evicts the oldest part-read page and aborts the list behind it", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, pageSize: 10 });
+    const list = loadHandlers(messages).get("messages.list");
+    const cursors = [];
+    for (let walks = 0; walks < 33; walks += 1) {
+      // Each one stops 3 messages into a 10-message page and is then abandoned.
+      cursors.push((await list({ folderId: FOLDER, limit: 3 })).cursor);
+    }
+
+    // The fake mints list ids in order, so the first walk's list is "list-1".
+    assert.deepEqual(
+      messages.calls.filter((call) => call.method === "abortList").map((call) => call.args[0]),
+      ["list-1"]
+    );
+    await assert.rejects(
+      () => list({ folderId: FOLDER, limit: 3, cursor: cursors[0] }),
+      usageError(/cursor/)
+    );
+    const newest = await list({ folderId: FOLDER, limit: 3, cursor: cursors.at(-1) });
+    assert.equal(newest.messages.length, 3, "the newest walk survived the eviction");
+  });
+
+  it("says a raw Thunderbird cursor has expired", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, pageSize: 10 });
+    const list = loadHandlers(messages).get("messages.list");
+
+    await assert.rejects(
+      () => list({ folderId: FOLDER, limit: 3, cursor: "list-404" }),
+      usageError(/expired/)
+    );
   });
 });

--- a/tests/js/messages.test.mjs
+++ b/tests/js/messages.test.mjs
@@ -111,4 +111,62 @@ describe("messages.query", () => {
 
     assert.deepEqual(ids(result), [100, 101, 102, 103, 104]);
   });
+
+  it("echoes the scope the query named, defaulting to sub-folders included", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    const query = loadHandlers(messages).get("messages.query");
+
+    const result = await query({ query: { subject: "Re", folderId: FOLDER }, limit: 5 });
+
+    assert.ok(result.scope, "a first page says what it searched");
+    assert.deepEqual(plain(result.scope), {
+      folderIds: [FOLDER],
+      accountIds: null,
+      includeSubFolders: true,
+    });
+  });
+
+  it("keeps the account scope and an explicit includeSubFolders", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    const query = loadHandlers(messages).get("messages.query");
+
+    const result = await query({
+      query: { subject: "Re", accountId: "account1", includeSubFolders: false },
+      limit: 5,
+    });
+
+    assert.equal(result.messages.length, 5);
+    assert.ok(result.scope, "a first page says what it searched");
+    assert.deepEqual(plain(result.scope), {
+      folderIds: null,
+      accountIds: ["account1"],
+      includeSubFolders: false,
+    });
+  });
+
+  it("reports a query that named no folder as unscoped", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    const query = loadHandlers(messages).get("messages.query");
+
+    const result = await query({ query: { subject: "Re" }, limit: 5 });
+
+    assert.ok(result.scope, "a first page says what it searched");
+    assert.deepEqual(plain(result.scope), {
+      folderIds: null,
+      accountIds: null,
+      includeSubFolders: false,
+    });
+  });
+
+  it("leaves the scope off a continuation page", async () => {
+    const messages = fakeMessages({ folders: { [FOLDER]: sample(30) }, queryPageSize: 10 });
+    const query = loadHandlers(messages).get("messages.query");
+    const params = { query: { subject: "Re", folderId: FOLDER }, limit: 5 };
+
+    const first = await query(params);
+    const next = await query({ ...params, cursor: first.cursor });
+
+    assert.equal(next.messages.length, 5, "the walk carried on");
+    assert.equal(next.scope, undefined, "the scope belongs to the first page only");
+  });
 });

--- a/tests/js/privileged.test.mjs
+++ b/tests/js/privileged.test.mjs
@@ -1,0 +1,113 @@
+/* The background page's side of the privileged hop.
+ *
+ * Everything the experiment throws arrives here as one string, because that is
+ * all that survives `normalizeError`. These tests are the other half of that
+ * contract: the tagged envelope is unpacked back into the taxonomy, and an
+ * untagged message still gets the guesswork it always got.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { fakeBrowser, fakeLog, loadScript, runInContext } from "./harness.mjs";
+
+/** registry.js and privileged.js in one page scope, as Thunderbird loads them. */
+function loadPrivileged(invoke, { methods = ["gloda.search"] } = {}) {
+  const browser = fakeBrowser();
+  browser.tbx.availableModules = async () => ({ methods });
+  browser.tbx.invoke = invoke;
+  const ctx = loadScript("background/registry.js", { browser, tbxLog: fakeLog() });
+  return runInContext(ctx, "background/handlers/privileged.js");
+}
+
+/** The error a call failed with; realms differ, so tests read its fields. */
+async function failure(promise) {
+  try {
+    await promise;
+  } catch (ex) {
+    return ex;
+  }
+  return assert.fail("the call was expected to fail");
+}
+
+/** What the experiment throws once wireError has packed it. */
+function tagged(payload) {
+  return async () => {
+    throw new Error(`tbxerr:${JSON.stringify(payload)}`);
+  };
+}
+
+describe("forwarding a privileged failure", () => {
+  it("unpacks a tagged usage error back into the taxonomy", async () => {
+    const ctx = loadPrivileged(tagged({ kind: "usage", message: "subject is required" }));
+
+    const ex = await failure(ctx.tbxRegistry.invoke("x.gloda.search", {}));
+
+    assert.equal(ex.tbxKind, "usage");
+    assert.equal(ex.message, "subject is required");
+  });
+
+  it("keeps what a blocked failure needs", async () => {
+    const ctx = loadPrivileged(
+      tagged({ kind: "blocked", message: "exists", needs: ["overwrite=true"] })
+    );
+
+    const ex = await failure(ctx.tbxRegistry.invoke("x.gloda.search", {}));
+
+    assert.equal(ex.tbxKind, "blocked");
+    assert.deepEqual([...ex.needs], ["overwrite=true"]);
+  });
+
+  it("carries the code the experiment reported", async () => {
+    const ctx = loadPrivileged(
+      tagged({ kind: "thunderbird", message: "t", code: "NS_ERROR_FAILURE" })
+    );
+
+    const ex = await failure(ctx.tbxRegistry.invoke("x.gloda.search", {}));
+
+    assert.equal(ex.code, "NS_ERROR_FAILURE");
+  });
+
+  it("treats a kind it does not know as Thunderbird's problem", async () => {
+    const ctx = loadPrivileged(tagged({ kind: "martian", message: "m" }));
+
+    const ex = await failure(ctx.tbxRegistry.invoke("x.gloda.search", {}));
+
+    assert.equal(ex.tbxKind, "thunderbird");
+    assert.equal(ex.message, "m");
+  });
+
+  it("still guesses at an untagged message, since older builds send those", async () => {
+    const required = loadPrivileged(async () => {
+      throw new Error("x is required");
+    });
+    const weird = loadPrivileged(async () => {
+      throw new Error("weird");
+    });
+
+    assert.equal(
+      (await failure(required.tbxRegistry.invoke("x.gloda.search", {}))).tbxKind,
+      "usage"
+    );
+    assert.equal(
+      (await failure(weird.tbxRegistry.invoke("x.gloda.search", {}))).tbxKind,
+      "thunderbird"
+    );
+  });
+});
+
+describe("tbxError.serialize", () => {
+  it("does not report a bare Error name as a code", () => {
+    const { tbxError } = loadScript("background/registry.js");
+
+    // "[Error]" told the model nothing and read like a second failure.
+    assert.equal(tbxError.serialize(new Error("boom")).code, null);
+  });
+
+  it("keeps a name that identifies the failure", () => {
+    const { tbxError } = loadScript("background/registry.js");
+
+    assert.equal(tbxError.serialize(new TypeError("t")).code, "TypeError");
+    assert.equal(tbxError.serialize(Object.assign(new Error("x"), { code: "E1" })).code, "E1");
+  });
+});

--- a/tests/js/privileged.test.mjs
+++ b/tests/js/privileged.test.mjs
@@ -111,3 +111,21 @@ describe("tbxError.serialize", () => {
     assert.equal(tbxError.serialize(Object.assign(new Error("x"), { code: "E1" })).code, "E1");
   });
 });
+
+describe("tbxError.fromWire", () => {
+  it("unpacks an envelope for any caller of the privileged half, not just forward()", () => {
+    const { tbxError } = loadScript("background/registry.js");
+
+    const ex = tbxError.fromWire(new Error('tbxerr:{"kind":"usage","message":"no such file"}'));
+
+    assert.equal(ex.tbxKind, "usage");
+    assert.equal(ex.message, "no such file");
+  });
+
+  it("does not claim a message that is not one of ours", () => {
+    const { tbxError } = loadScript("background/registry.js");
+
+    assert.equal(tbxError.fromWire(new Error("plain")), null);
+    assert.equal(tbxError.fromWire(new Error("tbxerr:not json")), null);
+  });
+});

--- a/tests/js/privileged.test.mjs
+++ b/tests/js/privileged.test.mjs
@@ -128,4 +128,68 @@ describe("tbxError.fromWire", () => {
     assert.equal(tbxError.fromWire(new Error("plain")), null);
     assert.equal(tbxError.fromWire(new Error("tbxerr:not json")), null);
   });
+
+  it("logs the message inside the envelope rather than the envelope", () => {
+    const { tbxError } = loadScript("background/registry.js");
+
+    assert.equal(
+      tbxError.readable(new Error('tbxerr:{"kind":"thunderbird","message":"the timer failed"}')),
+      "the timer failed"
+    );
+    assert.equal(tbxError.readable(new Error("plain")), "plain");
+  });
+});
+
+/** registry.js and the messages handlers in one page scope. */
+function loadMessages(writeFile) {
+  const browser = fakeBrowser();
+  browser.tbx.writeFile = writeFile;
+  browser.messages = {
+    getAttachmentFile: async () => ({
+      name: "invoice.pdf",
+      arrayBuffer: async () => new ArrayBuffer(0),
+    }),
+  };
+  const ctx = loadScript("background/registry.js", {
+    browser,
+    tbxLog: fakeLog(),
+    btoa: (binary) => Buffer.from(binary, "binary").toString("base64"),
+  });
+  return runInContext(ctx, "background/handlers/messages.js");
+}
+
+describe("saving an attachment through the privileged half", () => {
+  it("keeps a refused write refused, and says what would let it through", async () => {
+    const ctx = loadMessages(
+      tagged({
+        kind: "blocked",
+        message: "/out/invoice.pdf already exists",
+        needs: ["overwrite=true, or a different filename"],
+      })
+    );
+
+    const ex = await failure(
+      ctx.tbxRegistry.invoke("messages.saveAttachment", {
+        messageId: 42,
+        partName: "1.2",
+        directory: "/out",
+      })
+    );
+
+    assert.equal(ex.tbxKind, "blocked");
+    assert.equal(ex.message, "/out/invoice.pdf already exists");
+    assert.match([...ex.needs].join(" "), /overwrite=true/);
+  });
+
+  it("reports a write that worked", async () => {
+    const ctx = loadMessages(async () => ({ path: "/out/invoice.pdf", bytes: 0, name: "x.pdf" }));
+
+    const written = await ctx.tbxRegistry.invoke("messages.saveAttachment", {
+      messageId: 42,
+      partName: "1.2",
+      directory: "/out",
+    });
+
+    assert.equal(written.path, "/out/invoice.pdf");
+  });
 });

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -189,6 +189,64 @@ describe("capability snapshots", () => {
   });
 });
 
+describe("handshake watchdog", () => {
+  it("closes a socket that never gets its welcome", async () => {
+    const world = makeWorld();
+    const ws = await world.start();
+
+    ws.open();
+    assert.equal(world.transport.status().state, "handshaking");
+    await world.clock.advance(8000);
+
+    assert.deepEqual(ws.closeCalls, [{ code: 4000, reason: "no welcome" }]);
+    // A daemon that accepts and then ignores us is a failure, not a wait.
+    assert.equal(world.transport.status().attempt, 1);
+    assert.deepEqual(world.errors(), [
+      "no welcome from the daemon within 8000ms after hello — closing the socket; " +
+        "`tbmcp doctor` shows the daemon's view",
+    ]);
+  });
+
+  it("leaves a welcomed socket alone", async () => {
+    const world = makeWorld();
+    const ws = await world.start();
+
+    ws.open();
+    ws.receive({ t: "welcome" });
+    await world.clock.advance(8000);
+
+    assert.deepEqual(ws.closeCalls, []);
+    assert.deepEqual(world.errors(), []);
+    assert.equal(world.transport.status().state, "connected");
+  });
+});
+
+describe("connect watchdog", () => {
+  it("closes a socket that never finishes connecting", async () => {
+    const world = makeWorld();
+    const ws = await world.start();
+
+    await world.clock.advance(15000);
+
+    assert.deepEqual(ws.closeCalls, [{ code: 4000, reason: "connect timeout" }]);
+    assert.equal(world.errors().length, 1);
+    assert.match(world.errors()[0], /port 4711/);
+    assert.equal(world.transport.status().attempt, 1);
+  });
+
+  it("leaves a socket that opened in time alone", async () => {
+    const world = makeWorld();
+    const ws = await world.start();
+
+    ws.open();
+    ws.receive({ t: "welcome" });
+    await world.clock.advance(15000);
+
+    assert.deepEqual(ws.closeCalls, []);
+    assert.deepEqual(world.errors(), []);
+  });
+});
+
 describe("startup wiring", () => {
   /** Run main.js as Thunderbird would, against a transport that only records. */
   async function bootMain() {

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -247,6 +247,95 @@ describe("connect watchdog", () => {
   });
 });
 
+describe("re-entrancy", () => {
+  it("does not open a second socket while a connect is still reading the pairing", async () => {
+    let release;
+    const reading = new Promise((resolve) => (release = resolve));
+    const world = makeWorld({ pairing: () => reading });
+
+    world.transport.start({ app: null, capabilities: null });
+    await world.clock.advance(10000); // the supervisor ticks while the read hangs
+    assert.deepEqual(world.WebSocket.instances, []);
+
+    release(PAIRING);
+    await world.clock.advance(0);
+
+    assert.equal(world.WebSocket.instances.length, 1);
+  });
+
+  it("ignores a close from a socket it has already replaced", async () => {
+    const world = makeWorld();
+    const first = await world.start();
+    first.open();
+    first.receive({ t: "welcome" });
+    first.serverClose(1006, "daemon exited");
+    await world.clock.advance(600);
+    const second = world.WebSocket.instances[1];
+    second.open();
+    second.receive({ t: "welcome" });
+
+    first.serverClose(1006, "late notice");
+
+    assert.equal(world.transport.status().state, "connected");
+    await world.clock.advance(5000);
+    assert.equal(world.WebSocket.instances.length, 2);
+  });
+});
+
+describe("retry schedule", () => {
+  /** Advance to just before `delay`, then over it, counting sockets either side. */
+  async function expectRetryAfter(world, delay) {
+    const before = world.WebSocket.instances.length;
+    await world.clock.advance(delay - 1);
+    assert.equal(world.WebSocket.instances.length, before, `retried before ${delay}ms`);
+    await world.clock.advance(1);
+    assert.equal(world.WebSocket.instances.length, before + 1, `no retry at ${delay}ms`);
+  }
+
+  it("backs off while the same daemon keeps failing the handshake", async () => {
+    const world = makeWorld();
+    await world.start();
+
+    for (const delay of [500, 1000, 2000]) {
+      world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+      await expectRetryAfter(world, delay);
+    }
+
+    assert.equal(world.transport.status().attempt, 3);
+  });
+
+  it("polls instead of backing off when a daemon that was working goes away", async () => {
+    const world = makeWorld();
+    const ws = await world.start();
+    ws.open();
+    ws.receive({ t: "welcome" });
+
+    ws.serverClose(1006, "daemon exited");
+    await expectRetryAfter(world, 500);
+
+    // The daemon leaving is not this end failing, so nothing is backing off yet.
+    assert.equal(world.transport.status().attempt, 0);
+  });
+
+  it("starts the schedule over when a different daemon advertises itself", async () => {
+    let advertised = { version: 1, port: 4711, token: "old" };
+    const world = makeWorld({ pairing: () => advertised });
+    await world.start();
+    for (const delay of [500, 1000, 2000]) {
+      world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+      await expectRetryAfter(world, delay);
+    }
+
+    advertised = { version: 1, port: 4712, token: "new" };
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await expectRetryAfter(world, 4000);
+
+    assert.equal(world.WebSocket.instances.at(-1).url, "ws://127.0.0.1:4712/tbmcp");
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await expectRetryAfter(world, 500);
+  });
+});
+
 describe("startup wiring", () => {
   /** Run main.js as Thunderbird would, against a transport that only records. */
   async function bootMain() {

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -336,6 +336,58 @@ describe("retry schedule", () => {
   });
 });
 
+describe("supervisor", () => {
+  it("leaves a pending retry alone", async () => {
+    const world = makeWorld();
+    await world.start();
+
+    // Line the third failure up so the supervisor's 10s tick falls inside the 2s
+    // backoff that follows it — the case that used to turn every longer wait into
+    // a ten-second one.
+    await world.clock.advance(8000);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await world.clock.advance(500);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await world.clock.advance(1000);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    assert.equal(world.WebSocket.instances.length, 3);
+    assert.equal(world.clock.now(), 9500);
+
+    await world.clock.advance(1999); // the tick at 10000ms lands in here
+    assert.equal(world.WebSocket.instances.length, 3, "the tick pre-empted the backoff");
+    await world.clock.advance(1);
+    assert.equal(world.WebSocket.instances.length, 4);
+  });
+
+  it("has nothing left to run after stop()", async () => {
+    const world = makeWorld();
+    const ws = await world.start();
+    ws.open();
+    ws.receive({ t: "welcome" });
+
+    world.transport.stop();
+
+    assert.deepEqual(ws.closeCalls, [{ code: 1000, reason: "shutting down" }]);
+    await world.clock.advance(60000);
+    assert.equal(world.WebSocket.instances.length, 1);
+  });
+
+  it("follows the daemon when it moves to another port", async () => {
+    let advertised = { version: 1, port: 4711, token: "old" };
+    const world = makeWorld({ pairing: () => advertised });
+    const ws = await world.start();
+    ws.open();
+    ws.receive({ t: "welcome" });
+
+    advertised = { version: 1, port: 4712, token: "new" };
+    await world.clock.advance(10000);
+
+    assert.deepEqual(ws.closeCalls, [{ code: 1000, reason: "following the pairing file" }]);
+    await world.clock.advance(500);
+    assert.equal(world.WebSocket.instances.at(-1).url, "ws://127.0.0.1:4712/tbmcp");
+  });
+});
+
 describe("visible state", () => {
   const BACKOFF = [500, 1000, 2000, 4000];
 
@@ -381,11 +433,16 @@ describe("visible state", () => {
     recovered.open();
     recovered.receive({ t: "welcome" });
 
+    // The daemon going away does not count towards the next complaint...
     recovered.serverClose(1006, "daemon exited");
     await world.clock.advance(500);
-    for (let index = 0; index < 3; index += 1) {
+    for (let index = 0; index < 2; index += 1) {
       await failCycle(world, index);
     }
+    assert.equal(complaints(world).length, 1, "counted the daemon going away");
+
+    // ...only three attempts that never handshake do.
+    await failCycle(world, 2);
 
     assert.equal(complaints(world).length, 2);
   });
@@ -428,8 +485,16 @@ describe("status", () => {
     assert.equal(seen.length, 2);
     assert.equal(seen.at(-1).state, "disconnected");
     assert.equal(seen.at(-1).lastCloseCode, 1006);
-    assert.equal(seen.at(-1).consecutiveFailures, 1);
     assert.match(seen.at(-1).lastCloseAt, /^\d{4}-\d\d-\d\dT/);
+    // The daemon going away after a working session is not an attempt that failed.
+    assert.equal(seen.at(-1).consecutiveFailures, 0);
+
+    await world.clock.advance(500);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await world.clock.advance(500);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+
+    assert.equal(world.transport.status().consecutiveFailures, 2);
   });
 
   it("does not report every failure in a burst", async () => {

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -345,7 +345,8 @@ describe("visible state", () => {
     await world.clock.advance(BACKOFF[index]);
   }
 
-  const complaints = (world) => world.errors().filter((text) => text.includes("restart Thunderbird"));
+  const complaints = (world) =>
+    world.errors().filter((text) => text.includes("restart Thunderbird"));
 
   it("names every close and complains once when none of them handshake", async () => {
     const world = makeWorld();

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -31,22 +31,49 @@ function capabilityStub(overrides = {}) {
     describe: async () => ({ experiment: true, source: "async" }),
     appInfoSync: () => ({ name: "Thunderbird", version: "sync" }),
     describeSync: () => ({ experiment: true, source: "sync" }),
+    bounded: async (promise, _ms, fallback = null) => {
+      try {
+        return await promise;
+      } catch (ex) {
+        return fallback;
+      }
+    },
     ...overrides,
   };
 }
 
+/** The real capabilities module, against the same browser and clock. */
+function loadCapabilities({
+  browser = fakeBrowser(),
+  clock = fakeClock(),
+  methods = ["mail.list"],
+} = {}) {
+  const context = loadScript("background/capabilities.js", {
+    browser,
+    tbxLog: fakeLog(),
+    tbxRegistry: { methods: () => methods },
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+    console: quietConsole(),
+  });
+  return context.tbxCapabilities;
+}
+
 /** Load transport.js with every global it touches faked. */
-function makeWorld({ pairing = PAIRING, capabilities = {} } = {}) {
-  const clock = fakeClock();
+function makeWorld({
+  pairing = PAIRING,
+  browser = fakeBrowser({ pairing }),
+  clock = fakeClock(),
+  capabilities = capabilityStub(),
+} = {}) {
   const WebSocket = fakeWebSocketClass();
   const log = fakeLog();
-  const browser = fakeBrowser({ pairing });
   const context = loadScript("background/transport.js", {
     browser,
     WebSocket,
     tbxLog: log,
     tbxRegistry: { invoke: async () => ({}), methods: () => [] },
-    tbxCapabilities: capabilityStub(capabilities),
+    tbxCapabilities: capabilities,
     setTimeout: clock.setTimeout,
     clearTimeout: clock.clearTimeout,
     setInterval: clock.setInterval,
@@ -77,10 +104,10 @@ function makeWorld({ pairing = PAIRING, capabilities = {} } = {}) {
 describe("hello", () => {
   it("goes out as soon as the socket opens, even while a probe is hanging", async () => {
     const world = makeWorld({
-      capabilities: {
+      capabilities: capabilityStub({
         appInfo: () => new Promise(() => {}),
         describe: () => new Promise(() => {}),
-      },
+      }),
     });
     const ws = await world.start({
       app: { name: "Thunderbird", version: "155.0" },
@@ -125,42 +152,47 @@ describe("hello", () => {
     assert.deepEqual(next.sent[0].capabilities, { experiment: true, source: "async" });
   });
 
-  it("keeps the identity it has when the refresh fails", async () => {
-    const world = makeWorld({
-      capabilities: {
-        appInfo: async () => {
-          throw new Error("privileged half is gone");
-        },
-      },
-    });
-    const ws = await world.start({ app: { version: "seed" }, capabilities: { source: "seed" } });
+  it("keeps the identity it has when a refresh probe stops answering", async () => {
+    // The real capabilities module, because the guarantee lives in its cache: the
+    // probes never reject, so a refresh that "fails" still returns something.
+    const clock = fakeClock();
+    const browser = fakeBrowser({ pairing: PAIRING });
+    let answering = true;
+    const probe = (value) => async () => {
+      if (!answering) {
+        throw new Error("the privileged half is not answering");
+      }
+      return value;
+    };
+    browser.tbx.appInfo = probe({ name: "Thunderbird", version: "155.0" });
+    browser.tbx.availableModules = probe(["prefs", "smtp"]);
+    const capabilities = loadCapabilities({ browser, clock });
+    // main.js probes once before starting the transport; that is what fills the cache.
+    const identity = {
+      app: await capabilities.appInfo(),
+      capabilities: await capabilities.describe(),
+    };
+    answering = false;
+
+    const world = makeWorld({ browser, clock, capabilities });
+    const ws = await world.start(identity);
     ws.open();
     ws.receive({ t: "welcome" });
-    await world.clock.advance(0);
+    await clock.advance(0); // the refresh runs, and both probes fail
 
     ws.serverClose(1006, "daemon exited");
-    await world.clock.advance(600);
+    await clock.advance(600);
     const next = world.WebSocket.instances[1];
     next.open();
 
-    assert.deepEqual(next.sent[0].app, { version: "seed" });
+    assert.deepEqual(next.sent[0].app, { name: "Thunderbird", version: "155.0" });
+    assert.deepEqual(next.sent[0].capabilities.privilegedModules, ["prefs", "smtp"]);
   });
 });
 
 describe("capability snapshots", () => {
-  function loadCapabilities() {
-    const browser = fakeBrowser();
-    const context = loadScript("background/capabilities.js", {
-      browser,
-      tbxLog: fakeLog(),
-      tbxRegistry: { methods: () => ["mail.list"] },
-      console: quietConsole(),
-    });
-    return { capabilities: context.tbxCapabilities, browser };
-  }
-
   it("appInfoSync falls back to the manifest until a probe has answered", async () => {
-    const { capabilities } = loadCapabilities();
+    const capabilities = loadCapabilities();
 
     assert.deepEqual(plain(capabilities.appInfoSync()), {
       name: "Thunderbird",
@@ -175,8 +207,34 @@ describe("capability snapshots", () => {
     });
   });
 
+  it("bounded answers with the fallback when a probe never does", async () => {
+    const clock = fakeClock();
+    const capabilities = loadCapabilities({ clock });
+    let settled = "pending";
+
+    capabilities.bounded(new Promise(() => {}), 5000, "gave up").then((value) => {
+      settled = value;
+    });
+
+    await clock.advance(4999);
+    assert.equal(settled, "pending");
+    await clock.advance(1);
+    assert.equal(settled, "gave up");
+  });
+
+  it("bounded passes an answer through, and a failure becomes the fallback", async () => {
+    const capabilities = loadCapabilities();
+
+    assert.equal(await capabilities.bounded(Promise.resolve("answer"), 5000, "no"), "answer");
+    assert.equal(
+      await capabilities.bounded(Promise.reject(new Error("wedged")), 5000, "no"),
+      "no"
+    );
+    assert.equal(await capabilities.bounded(Promise.resolve(7), 5000), 7);
+  });
+
   it("describeSync has describe()'s shape, without a probe of its own", async () => {
-    const { capabilities } = loadCapabilities();
+    const capabilities = loadCapabilities();
 
     const before = plain(capabilities.describeSync());
     assert.deepEqual(before.privilegedModules, []);
@@ -336,6 +394,39 @@ describe("retry schedule", () => {
   });
 });
 
+describe("pairing read", () => {
+  it("gives up on a read that never answers, and drops its late answer", async () => {
+    let release;
+    const hung = new Promise((resolve) => (release = resolve));
+    let reads = 0;
+    const world = makeWorld({
+      pairing: () => {
+        reads += 1;
+        return reads === 1 ? hung : PAIRING;
+      },
+    });
+
+    world.transport.start({ app: null, capabilities: null });
+    await world.clock.advance(0);
+    assert.equal(world.transport.status().connecting, true);
+
+    await world.clock.advance(5000);
+
+    assert.match(world.errors().at(-1), /readBridgeFile did not answer within 5000ms/);
+    assert.equal(world.transport.status().connecting, false);
+    assert.deepEqual(world.WebSocket.instances, []);
+
+    await world.clock.advance(500); // the first step of the failed schedule
+    assert.equal(reads, 2);
+    assert.equal(world.WebSocket.instances.length, 1);
+
+    release(PAIRING); // the read that timed out finally answers
+    await world.clock.advance(0);
+
+    assert.equal(world.WebSocket.instances.length, 1);
+  });
+});
+
 describe("supervisor", () => {
   it("leaves a pending retry alone", async () => {
     const world = makeWorld();
@@ -421,6 +512,23 @@ describe("visible state", () => {
     assert.equal(complaints(world).length, 1, "complained more than once");
   });
 
+  it("does not blame a new daemon for the last one's failures", async () => {
+    let advertised = { version: 1, port: 4711, token: "old" };
+    const world = makeWorld({ pairing: () => advertised });
+    await world.start();
+
+    await failCycle(world, 0);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    advertised = { version: 1, port: 4712, token: "new" };
+    await world.clock.advance(1000);
+
+    assert.equal(world.WebSocket.instances.at(-1).url, "ws://127.0.0.1:4712/tbmcp");
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+
+    assert.deepEqual(complaints(world), []);
+    assert.equal(world.transport.status().consecutiveFailures, 1);
+  });
+
   it("complains again only after a welcome has reset the count", async () => {
     const world = makeWorld();
     await world.start();
@@ -454,6 +562,7 @@ describe("status", () => {
 
     assert.deepEqual(plain(world.transport.status()), {
       state: "disconnected",
+      connecting: false,
       attempt: 0,
       inFlight: 0,
       consecutiveFailures: 0,
@@ -536,6 +645,36 @@ describe("startup wiring", () => {
     await settle();
     return { browser, starts };
   }
+
+  it("starts the transport even when the privileged half never answers", async () => {
+    const clock = fakeClock();
+    const browser = fakeBrowser({ pairing: PAIRING });
+    const hang = () => new Promise(() => {});
+    for (const call of ["keepAlive", "grantOptionalPermission", "appInfo", "availableModules"]) {
+      browser.tbx[call] = hang;
+    }
+    browser.tbx.writeStatus = hang;
+    const starts = [];
+    loadScript("background/main.js", {
+      browser,
+      tbxLog: fakeLog(),
+      tbxRegistry: { methods: () => ["mail.list"] },
+      tbxCapabilities: loadCapabilities({ browser, clock }),
+      tbxEvents: { start() {} },
+      tbxTransport: {
+        start: (identity, options) => starts.push({ identity, options }),
+        stop() {},
+      },
+      console: quietConsole(),
+      Date,
+    });
+
+    await settle(); // main.js gets as far as its first bounded call
+    await clock.advance(30000);
+
+    assert.equal(starts.length, 1, "the transport never started");
+    assert.deepEqual(plain(starts[0].identity), { app: null, capabilities: null });
+  });
 
   it("keeps the status file up to date as the transport changes state", async () => {
     const { browser, starts } = await bootMain();

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -1,0 +1,224 @@
+/* The dial-out half of the bridge, driven without a Thunderbird or a daemon.
+ *
+ * Everything here reproduces a failure seen against a real one: a handshake that
+ * never completes, a probe that never resolves, two sockets racing, or a retry
+ * loop that hammers a daemon that will never answer.
+ */
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import { fakeBrowser, fakeClock, fakeLog, fakeWebSocketClass, loadScript } from "./harness.mjs";
+
+const PAIRING = { version: 1, port: 4711, token: "tok" };
+
+/** Let already-resolved promises run to completion. */
+const settle = () => new Promise((resolve) => setImmediate(resolve));
+
+/** Values built inside the vm carry that realm's prototypes; strip them. */
+function plain(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function quietConsole() {
+  const noop = () => {};
+  return { log: noop, info: noop, warn: noop, error: noop, debug: noop };
+}
+
+function capabilityStub(overrides = {}) {
+  return {
+    appInfo: async () => ({ name: "Thunderbird", version: "async" }),
+    describe: async () => ({ experiment: true, source: "async" }),
+    appInfoSync: () => ({ name: "Thunderbird", version: "sync" }),
+    describeSync: () => ({ experiment: true, source: "sync" }),
+    ...overrides,
+  };
+}
+
+/** Load transport.js with every global it touches faked. */
+function makeWorld({ pairing = PAIRING, capabilities = {} } = {}) {
+  const clock = fakeClock();
+  const WebSocket = fakeWebSocketClass();
+  const log = fakeLog();
+  const browser = fakeBrowser({ pairing });
+  const context = loadScript("background/transport.js", {
+    browser,
+    WebSocket,
+    tbxLog: log,
+    tbxRegistry: { invoke: async () => ({}), methods: () => [] },
+    tbxCapabilities: capabilityStub(capabilities),
+    setTimeout: clock.setTimeout,
+    clearTimeout: clock.clearTimeout,
+    setInterval: clock.setInterval,
+    clearInterval: clock.clearInterval,
+    TextEncoder,
+    btoa,
+    JSON,
+    console: quietConsole(),
+    Date,
+  });
+  const world = {
+    clock,
+    WebSocket,
+    log,
+    browser,
+    transport: context.tbxTransport,
+    /** Start the transport and return the socket it opens. */
+    async start(identity = { app: null, capabilities: null }, options = undefined) {
+      world.transport.start(identity, options);
+      await clock.advance(0);
+      return WebSocket.instances[0];
+    },
+    errors: () => log.records.filter((record) => record.level === "error").map((r) => r.text),
+  };
+  return world;
+}
+
+describe("hello", () => {
+  it("goes out as soon as the socket opens, even while a probe is hanging", async () => {
+    const world = makeWorld({
+      capabilities: {
+        appInfo: () => new Promise(() => {}),
+        describe: () => new Promise(() => {}),
+      },
+    });
+    const ws = await world.start({
+      app: { name: "Thunderbird", version: "155.0" },
+      capabilities: { experiment: true },
+    });
+
+    ws.open();
+
+    assert.deepEqual(ws.sent[0], {
+      t: "hello",
+      token: "tok",
+      protocol: 1,
+      addonVersion: "9.9.9",
+      app: { name: "Thunderbird", version: "155.0" },
+      capabilities: { experiment: true },
+    });
+  });
+
+  it("falls back to the cached snapshots when started without an identity", async () => {
+    const world = makeWorld();
+    const ws = await world.start({ app: null, capabilities: null });
+
+    ws.open();
+
+    assert.deepEqual(ws.sent[0].app, { name: "Thunderbird", version: "sync" });
+    assert.deepEqual(ws.sent[0].capabilities, { experiment: true, source: "sync" });
+  });
+
+  it("carries values refreshed after the last welcome", async () => {
+    const world = makeWorld();
+    const ws = await world.start({ app: { version: "seed" }, capabilities: { source: "seed" } });
+    ws.open();
+    ws.receive({ t: "welcome" });
+    await world.clock.advance(0);
+
+    ws.serverClose(1006, "daemon exited");
+    await world.clock.advance(600);
+    const next = world.WebSocket.instances[1];
+    next.open();
+
+    assert.deepEqual(next.sent[0].app, { name: "Thunderbird", version: "async" });
+    assert.deepEqual(next.sent[0].capabilities, { experiment: true, source: "async" });
+  });
+
+  it("keeps the identity it has when the refresh fails", async () => {
+    const world = makeWorld({
+      capabilities: {
+        appInfo: async () => {
+          throw new Error("privileged half is gone");
+        },
+      },
+    });
+    const ws = await world.start({ app: { version: "seed" }, capabilities: { source: "seed" } });
+    ws.open();
+    ws.receive({ t: "welcome" });
+    await world.clock.advance(0);
+
+    ws.serverClose(1006, "daemon exited");
+    await world.clock.advance(600);
+    const next = world.WebSocket.instances[1];
+    next.open();
+
+    assert.deepEqual(next.sent[0].app, { version: "seed" });
+  });
+});
+
+describe("capability snapshots", () => {
+  function loadCapabilities() {
+    const browser = fakeBrowser();
+    const context = loadScript("background/capabilities.js", {
+      browser,
+      tbxLog: fakeLog(),
+      tbxRegistry: { methods: () => ["mail.list"] },
+      console: quietConsole(),
+    });
+    return { capabilities: context.tbxCapabilities, browser };
+  }
+
+  it("appInfoSync falls back to the manifest until a probe has answered", async () => {
+    const { capabilities } = loadCapabilities();
+
+    assert.deepEqual(plain(capabilities.appInfoSync()), {
+      name: "Thunderbird",
+      version: "unknown",
+      addon: "9.9.9",
+    });
+
+    await capabilities.appInfo();
+    assert.deepEqual(plain(capabilities.appInfoSync()), {
+      name: "Thunderbird",
+      version: "155.0",
+    });
+  });
+
+  it("describeSync has describe()'s shape, without a probe of its own", async () => {
+    const { capabilities } = loadCapabilities();
+
+    const before = plain(capabilities.describeSync());
+    assert.deepEqual(before.privilegedModules, []);
+    assert.equal(before.experiment, true);
+    assert.deepEqual(before.methods, ["mail.list"]);
+
+    const described = plain(await capabilities.describe());
+    assert.deepEqual(plain(capabilities.describeSync()), described);
+    assert.deepEqual(described.privilegedModules, { loaded: [], methods: [], resolvable: [] });
+  });
+});
+
+describe("startup wiring", () => {
+  /** Run main.js as Thunderbird would, against a transport that only records. */
+  async function bootMain() {
+    const browser = fakeBrowser({ pairing: PAIRING });
+    const starts = [];
+    loadScript("background/main.js", {
+      browser,
+      tbxLog: fakeLog(),
+      tbxRegistry: { methods: () => ["mail.list"] },
+      tbxCapabilities: capabilityStub(),
+      tbxEvents: { start() {} },
+      tbxTransport: {
+        start: (identity, options) => starts.push({ identity, options }),
+        stop() {},
+      },
+      console: quietConsole(),
+      Date,
+    });
+    await settle();
+    return { browser, starts };
+  }
+
+  it("hands the transport the identity it fetched for the status file", async () => {
+    const { browser, starts } = await bootMain();
+
+    assert.equal(starts.length, 1);
+    assert.deepEqual(plain(starts[0].identity), {
+      app: { name: "Thunderbird", version: "async" },
+      capabilities: { experiment: true, source: "async" },
+    });
+    assert.deepEqual(plain(browser._written[0].app), { name: "Thunderbird", version: "async" });
+  });
+});

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -336,6 +336,119 @@ describe("retry schedule", () => {
   });
 });
 
+describe("visible state", () => {
+  const BACKOFF = [500, 1000, 2000, 4000];
+
+  /** Close the live socket and wait out the retry, once per call. */
+  async function failCycle(world, index) {
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await world.clock.advance(BACKOFF[index]);
+  }
+
+  const complaints = (world) => world.errors().filter((text) => text.includes("restart Thunderbird"));
+
+  it("names every close and complains once when none of them handshake", async () => {
+    const world = makeWorld();
+    await world.start();
+
+    for (let index = 0; index < 3; index += 1) {
+      await failCycle(world, index);
+    }
+
+    assert.deepEqual(
+      world.log.records.filter((record) => record.level === "info").map((r) => r.text),
+      new Array(3).fill("socket closed (code 1006: closed by the daemon)")
+    );
+    assert.deepEqual(complaints(world), [
+      "the daemon on port 4711 accepted 3 connections but none completed the handshake — " +
+        "restart Thunderbird if this persists; `tbmcp doctor` shows the daemon's view",
+    ]);
+
+    await failCycle(world, 3);
+    assert.equal(complaints(world).length, 1, "complained more than once");
+  });
+
+  it("complains again only after a welcome has reset the count", async () => {
+    const world = makeWorld();
+    await world.start();
+    for (let index = 0; index < 3; index += 1) {
+      await failCycle(world, index);
+    }
+    assert.equal(complaints(world).length, 1);
+
+    const recovered = world.WebSocket.instances.at(-1);
+    recovered.open();
+    recovered.receive({ t: "welcome" });
+
+    recovered.serverClose(1006, "daemon exited");
+    await world.clock.advance(500);
+    for (let index = 0; index < 3; index += 1) {
+      await failCycle(world, index);
+    }
+
+    assert.equal(complaints(world).length, 2);
+  });
+});
+
+describe("status", () => {
+  it("reports the whole picture before anything has happened", () => {
+    const world = makeWorld();
+
+    assert.deepEqual(plain(world.transport.status()), {
+      state: "disconnected",
+      attempt: 0,
+      inFlight: 0,
+      consecutiveFailures: 0,
+      lastCloseCode: null,
+      lastCloseAt: null,
+      lastWelcomeAt: null,
+      port: null,
+    });
+  });
+
+  it("announces the bridge coming up and the connection failing", async () => {
+    const world = makeWorld();
+    const seen = [];
+    const ws = await world.start(
+      { app: null, capabilities: null },
+      { onStateChange: (report) => seen.push(plain(report)) }
+    );
+
+    ws.open();
+    ws.receive({ t: "welcome" });
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen.at(-1).state, "connected");
+    assert.equal(seen.at(-1).port, 4711);
+    assert.match(seen.at(-1).lastWelcomeAt, /^\d{4}-\d\d-\d\dT/);
+
+    ws.serverClose(1006, "daemon exited");
+
+    assert.equal(seen.length, 2);
+    assert.equal(seen.at(-1).state, "disconnected");
+    assert.equal(seen.at(-1).lastCloseCode, 1006);
+    assert.equal(seen.at(-1).consecutiveFailures, 1);
+    assert.match(seen.at(-1).lastCloseAt, /^\d{4}-\d\d-\d\dT/);
+  });
+
+  it("does not report every failure in a burst", async () => {
+    const world = makeWorld();
+    const seen = [];
+    await world.start(
+      { app: null, capabilities: null },
+      { onStateChange: (report) => seen.push(plain(report)) }
+    );
+
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await world.clock.advance(500);
+    world.WebSocket.instances.at(-1).serverClose(1006, "closed by the daemon");
+    await world.clock.advance(1000);
+
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].consecutiveFailures, 1);
+  });
+});
+
 describe("startup wiring", () => {
   /** Run main.js as Thunderbird would, against a transport that only records. */
   async function bootMain() {
@@ -357,6 +470,22 @@ describe("startup wiring", () => {
     await settle();
     return { browser, starts };
   }
+
+  it("keeps the status file up to date as the transport changes state", async () => {
+    const { browser, starts } = await bootMain();
+    const before = plain(browser._written[0]);
+
+    starts[0].options.onStateChange({ state: "connected", port: 4711 });
+    await settle();
+
+    assert.equal(browser._written.length, 2);
+    const after = plain(browser._written[1]);
+    assert.deepEqual(after.transport, { state: "connected", port: 4711 });
+    for (const key of ["addonVersion", "app", "capabilities", "methodCount"]) {
+      assert.deepEqual(after[key], before[key], `${key} was lost`);
+    }
+    assert.ok(after.writtenAt >= before.writtenAt, "writtenAt went backwards");
+  });
 
   it("hands the transport the identity it fetched for the status file", async () => {
     const { browser, starts } = await bootMain();

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -42,6 +42,9 @@ function capabilityStub(overrides = {}) {
   };
 }
 
+/** The error helpers, from the script that declares them; registry.js loads first. */
+const { tbxError } = loadScript("background/registry.js");
+
 /** The real capabilities module, against the same browser and clock. */
 function loadCapabilities({
   browser = fakeBrowser(),
@@ -50,6 +53,7 @@ function loadCapabilities({
 } = {}) {
   const context = loadScript("background/capabilities.js", {
     browser,
+    tbxError,
     tbxLog: fakeLog(),
     tbxRegistry: { methods: () => methods },
     setTimeout: clock.setTimeout,
@@ -659,6 +663,7 @@ describe("startup wiring", () => {
     const starts = [];
     loadScript("background/main.js", {
       browser,
+      tbxError,
       tbxLog: fakeLog(),
       tbxRegistry: { methods: () => ["mail.list"] },
       tbxCapabilities: capabilityStub(),
@@ -685,6 +690,7 @@ describe("startup wiring", () => {
     const starts = [];
     loadScript("background/main.js", {
       browser,
+      tbxError,
       tbxLog: fakeLog(),
       tbxRegistry: { methods: () => ["mail.list"] },
       tbxCapabilities: loadCapabilities({ browser, clock }),

--- a/tests/js/transport.test.mjs
+++ b/tests/js/transport.test.mjs
@@ -395,6 +395,34 @@ describe("retry schedule", () => {
 });
 
 describe("pairing read", () => {
+  it("keeps each read's deadline to itself", async () => {
+    const hung = [];
+    const world = makeWorld({ pairing: () => new Promise((resolve) => hung.push(resolve)) });
+
+    world.transport.start({ app: null, capabilities: null });
+    await world.clock.advance(0);
+    assert.equal(hung.length, 1);
+
+    await world.clock.advance(5000); // the first read is given up on
+    assert.equal(world.errors().length, 1);
+    assert.equal(world.transport.status().connecting, false);
+
+    await world.clock.advance(500); // and the retry starts a second one
+    assert.equal(hung.length, 2);
+    assert.equal(world.transport.status().connecting, true);
+
+    hung[0](PAIRING); // the abandoned read answers while the second is still waiting
+    await world.clock.advance(0);
+    assert.deepEqual(world.WebSocket.instances, []);
+
+    await world.clock.advance(5000); // the second read's own deadline must still land
+
+    assert.equal(world.errors().length, 2, "the late answer disarmed the live watchdog");
+    assert.equal(world.transport.status().connecting, false);
+    await world.clock.advance(1000);
+    assert.equal(hung.length, 3);
+  });
+
   it("gives up on a read that never answers, and drops its late answer", async () => {
     let release;
     const hung = new Promise((resolve) => (release = resolve));

--- a/tests/test_addon_build.py
+++ b/tests/test_addon_build.py
@@ -139,3 +139,15 @@ def test_a_module_that_does_not_announce_itself_is_rejected(tmp_path) -> None:
     )
     with pytest.raises(ValueError, match="TBX_MODULE_NAMES"):
         assemble_implementation(source)
+
+
+def test_the_globals_the_sandbox_lacks_are_imported(built) -> None:
+    """Two things the privileged half needs and the ext-*.js sandbox does not inject.
+
+    A bare `setTimeout` is a ReferenceError there, which surfaces only as a
+    capability that never answers; and without `ExtensionError` every failure
+    reaches the background page as "An unexpected error occurred".
+    """
+    _, _, implementation = built
+    assert "resource://gre/modules/Timer.sys.mjs" in implementation
+    assert "resource://gre/modules/ExtensionUtils.sys.mjs" in implementation

--- a/tests/test_addon_build.py
+++ b/tests/test_addon_build.py
@@ -74,6 +74,20 @@ def test_every_background_script_ships(built) -> None:
         assert script in names, f"{script} is in the manifest but not in the package"
 
 
+def test_manifest_permissions_are_known_to_thunderbird() -> None:
+    """An unknown permission is not a no-op.
+
+    Thunderbird 155 logs `Error processing permissions.17: Value "messages.tags"`
+    at install time; the real names are messagesTags and messagesTagsList, which
+    are already listed.
+    """
+    import json
+
+    manifest = json.loads((addon_source_dir() / "manifest.json").read_text(encoding="utf-8"))
+    assert "messages.tags" not in manifest["permissions"]
+    assert {"messagesTags", "messagesTagsList"} <= set(manifest["permissions"])
+
+
 def test_build_is_reproducible(tmp_path) -> None:
     first = build_xpi(tmp_path / "a")
     second = build_xpi(tmp_path / "b")

--- a/tests/test_addon_build.py
+++ b/tests/test_addon_build.py
@@ -151,3 +151,13 @@ def test_the_globals_the_sandbox_lacks_are_imported(built) -> None:
     _, _, implementation = built
     assert "resource://gre/modules/Timer.sys.mjs" in implementation
     assert "resource://gre/modules/ExtensionUtils.sys.mjs" in implementation
+
+
+def test_nothing_type_checks_a_date_by_instance(built) -> None:
+    """Thunderbird hands the privileged half objects minted in its own realms.
+
+    `value instanceof Date` is false for every Date gloda produces, which is how
+    each search hit came back with `date: null`.
+    """
+    _, _, implementation = built
+    assert "instanceof Date" not in implementation

--- a/tests/test_addon_install_flow.py
+++ b/tests/test_addon_install_flow.py
@@ -137,3 +137,20 @@ def test_a_normal_success_restarts_once(flow):
 
     assert outcome.ok
     assert calls["restart"] == 1
+
+
+def test_the_failure_text_does_not_claim_a_restart_that_no_restart_prevented(flow):
+    client = FakeClient(
+        install_report=None,
+        status_report={"installed": True, "version": "1.0.0", "isActive": False},
+    )
+    calls = flow(client)
+
+    with pytest.raises(TbmcpError) as caught:
+        addon_install.install_automatic(restart_after=False)
+
+    text = str(caught.value)
+    assert "left stopped" in text
+    assert "is being restarted" not in text
+    # The restart hook is still invoked — it is the hook that honours the flag.
+    assert calls["restart"] == 1

--- a/tests/test_addon_install_flow.py
+++ b/tests/test_addon_install_flow.py
@@ -1,0 +1,139 @@
+"""`install-addon` must never leave Thunderbird stopped.
+
+Seen live: the add-on was installed and had already attached to the daemon, but the
+Marionette call that ran the install script answered `None`. `install_automatic`
+raised before any restart, so the command failed *and* the user's mail client
+stayed closed — a worse state than before the command ran.
+
+The rule is simple: once we stopped Thunderbird, we restart it on every exit path,
+and an unreadable install report is checked against the AddonManager before it is
+allowed to count as a failure.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+
+from tbmcp import addon_install
+from tbmcp.errors import TbmcpError
+
+EXPECTED_VERSION = "9.9.9"
+
+
+class FakeClient:
+    """Just enough Marionette: the install script answers `install_report`, the
+    status script answers `status_report`, anything else raises `blow_up`."""
+
+    def __init__(self, install_report, status_report=None, blow_up=None):
+        self.install_report = install_report
+        self.status_report = status_report
+        self.blow_up = blow_up
+        self.quit_calls = 0
+        self.close_calls = 0
+
+    def start_chrome_session(self):
+        return {}
+
+    def execute(self, script, args=None, *, timeout_ms=0):
+        if self.blow_up is not None:
+            raise self.blow_up
+        if script is addon_install.INSTALL_SCRIPT:
+            return self.install_report
+        if script is addon_install.STATUS_SCRIPT:
+            return self.status_report
+        raise AssertionError("unexpected script")
+
+    def quit_application(self):
+        self.quit_calls += 1
+
+    def close(self):
+        self.close_calls += 1
+
+
+@pytest.fixture
+def flow(monkeypatch, tmp_path):
+    """Stub every seam that touches the machine; record the restarts."""
+    calls = {"restart": 0, "stop": 0, "launch": []}
+    package = tmp_path / "bridge.xpi"
+    package.write_bytes(b"not really a zip")
+
+    monkeypatch.setattr(addon_install, "find_thunderbird", lambda: pathlib.Path("tb.exe"))
+    monkeypatch.setattr(addon_install, "build_xpi", lambda _dest: package)
+    monkeypatch.setattr(addon_install, "addon_id", lambda: "bridge@example")
+    monkeypatch.setattr(addon_install, "addon_version", lambda src=None: EXPECTED_VERSION)
+    monkeypatch.setattr(addon_install, "is_running", lambda: True)
+
+    def stop(timeout=60.0):
+        calls["stop"] += 1
+        return True
+
+    def launch(exe, extra_args, profile):
+        calls["launch"].append(list(extra_args))
+
+    def restart(exe, profile, restart):
+        calls["restart"] += 1
+
+    monkeypatch.setattr(addon_install, "_stop", stop)
+    monkeypatch.setattr(addon_install, "_launch", launch)
+    monkeypatch.setattr(addon_install, "_restart_plain", restart)
+    monkeypatch.setattr(addon_install.marionette, "wait_for_port", lambda timeout=0: True)
+
+    def use(client):
+        monkeypatch.setattr(addon_install.marionette, "connect", lambda timeout=0: client)
+        return calls
+
+    return use
+
+
+def test_an_unreadable_install_report_is_checked_before_it_counts_as_a_failure(flow):
+    client = FakeClient(
+        install_report=None,
+        status_report={"installed": True, "version": EXPECTED_VERSION, "isActive": True},
+    )
+    calls = flow(client)
+
+    outcome = addon_install.install_automatic()
+
+    assert outcome.ok, outcome.message
+    assert EXPECTED_VERSION in outcome.message
+    assert calls["restart"] == 1, "Thunderbird must be restarted exactly once"
+    assert client.quit_calls == 1, "Marionette must still be taken down"
+
+
+def test_an_unreadable_report_with_a_bad_status_fails_but_still_restarts(flow):
+    client = FakeClient(
+        install_report=None,
+        status_report={"installed": True, "version": "1.0.0", "isActive": False},
+    )
+    calls = flow(client)
+
+    with pytest.raises(TbmcpError) as caught:
+        addon_install.install_automatic()
+
+    assert "restarted" in str(caught.value).lower()
+    assert calls["restart"] == 1
+
+
+def test_a_failure_inside_the_automation_still_restarts_thunderbird(flow):
+    client = FakeClient(install_report=None, blow_up=RuntimeError("marionette exploded"))
+    calls = flow(client)
+
+    with pytest.raises(RuntimeError):
+        addon_install.install_automatic()
+
+    assert calls["restart"] == 1
+    assert client.quit_calls == 1
+
+
+def test_a_normal_success_restarts_once(flow):
+    client = FakeClient(
+        install_report={"result": {"ok": True, "version": EXPECTED_VERSION, "isActive": True}}
+    )
+    calls = flow(client)
+
+    outcome = addon_install.install_automatic()
+
+    assert outcome.ok
+    assert calls["restart"] == 1

--- a/tests/test_bootstrap_entry.py
+++ b/tests/test_bootstrap_entry.py
@@ -38,7 +38,7 @@ def test_module_imports_without_the_package_on_the_path(tmp_path):
         env=env,
     )
     assert done.returncode == 0, done.stderr
-    assert "1.2.0" in done.stdout
+    assert "1.3.0" in done.stdout
 
 
 def test_root_shim_exists_and_delegates():
@@ -66,7 +66,7 @@ def test_root_shim_actually_runs_and_produces_the_five_key_contract(tmp_path):
     assert done.returncode in (0, 1), done.stderr
     payload = json.loads(done.stdout)
     assert set(payload) == {"ok", "version", "launcher", "steps", "next_command"}
-    assert payload["version"] == "1.2.0"
+    assert payload["version"] == "1.3.0"
     assert payload["steps"]  # ran the real step sequence, not a stub
 
 
@@ -92,7 +92,7 @@ def test_main_returns_nonzero_when_a_step_fails(monkeypatch, capsys):
     monkeypatch.setattr(
         module,
         "bootstrap",
-        lambda options, **kw: module.Report(False, "1.2.0", None, [], "tbmcp doctor"),
+        lambda options, **kw: module.Report(False, "1.3.0", None, [], "tbmcp doctor"),
     )
     assert module.main(["--json"]) == 1
     assert '"ok": false' in capsys.readouterr().out
@@ -110,7 +110,7 @@ def test_main_exits_zero_for_a_clean_dry_run(monkeypatch, capsys):
     monkeypatch.setattr(
         module,
         "bootstrap",
-        lambda options, **kw: module.Report(False, "1.2.0", None, steps, "python bootstrap.py"),
+        lambda options, **kw: module.Report(False, "1.3.0", None, steps, "python bootstrap.py"),
     )
     assert module.main(["--dry-run", "--json"]) == 0
     out = capsys.readouterr().out
@@ -130,7 +130,7 @@ def test_main_still_exits_nonzero_when_a_dry_run_step_failed(monkeypatch, capsys
         module,
         "bootstrap",
         lambda options, **kw: module.Report(
-            False, "1.2.0", None, steps, "python bootstrap.py --python <path>"
+            False, "1.3.0", None, steps, "python bootstrap.py --python <path>"
         ),
     )
     assert module.main(["--dry-run", "--json"]) == 1

--- a/tests/test_bootstrap_run.py
+++ b/tests/test_bootstrap_run.py
@@ -173,7 +173,7 @@ def test_json_is_machine_readable(tmp_path):
     report = bootstrap(Options(venv=tmp_path / "venv", dry_run=True), run=recorder.run)
     payload = json.loads(report.to_json())
     assert payload["ok"] is False  # dry run: see test_dry_run_is_never_reported_ok
-    assert payload["version"] == "1.2.0"
+    assert payload["version"] == "1.3.0"
     assert [s["name"] for s in payload["steps"]] == STEPS
     assert set(payload) == {"ok", "version", "launcher", "steps", "next_command"}
 

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -417,3 +417,21 @@ def test_the_daemon_log_is_named_because_nothing_else_shows_it(monkeypatch, tmp_
     assert "daemon.log" in out
     assert "add-on handshakes" in out
     assert "none since the daemon started" in out
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_a_stale_addon_is_named_even_while_thunderbird_is_closed(monkeypatch, tmp_path, capsys):
+    """The remedy used to hide behind "Thunderbird is not running": a user with a stale
+    add-on and a closed client was told only to start it, and came straight back."""
+    _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={"connected": False},
+        addon_summary={"addonVersion": "1.3.0", "thunderbirdRunning": False},
+        profile=_profile(tmp_path, {**_ADDON_STATUS, "addonVersion": "1.2.0"}),
+    )
+
+    out = capsys.readouterr().out
+    assert "Thunderbird is not running" in out
+    assert "installed add-on is 1.2.0, source is 1.3.0" in out
+    assert "tbmcp install-addon" in out

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -11,11 +11,14 @@ chain (new breakage #4).
 
 from __future__ import annotations
 
+import json
+import time
 from types import SimpleNamespace
 
 import pytest
 
 from tbmcp.cli import _doctor_ok, build_parser, cmd_doctor
+from tbmcp.profile import ThunderbirdProfile
 
 # ------------------------------------------------------------------- _doctor_ok
 
@@ -82,9 +85,19 @@ def _clean_tbmcp_env(monkeypatch):
         monkeypatch.delenv(var, raising=False)
 
 
-def _stub_common(monkeypatch, *, bridge_status: dict) -> tuple[list, list]:
+def _stub_common(
+    monkeypatch,
+    *,
+    bridge_status: dict,
+    addon_summary: dict | None = None,
+    profile=None,
+) -> list:
     """Fake every dependency `cmd_doctor` reaches for besides `Bridge`/`build_server`,
-    which each test fakes itself. Returns (created_bridges, build_server_calls).
+    which each test fakes itself. Returns the bridges that were constructed.
+
+    `addon_summary` stands in for `addon_install.summary()` (the version in *this*
+    package's source), and `profile` for a real profile directory — the version the
+    add-on actually installed is read out of the status file it leaves there.
     """
     created_bridges: list = []
 
@@ -106,9 +119,9 @@ def _stub_common(monkeypatch, *, bridge_status: dict) -> tuple[list, list]:
             self.closed = True
 
     monkeypatch.setattr("tbmcp.bridge.Bridge", FakeBridge)
-    monkeypatch.setattr("tbmcp.profile.list_profiles", lambda: [])
-    monkeypatch.setattr("tbmcp.profile.find_profile", lambda *_a, **_k: None)
-    monkeypatch.setattr("tbmcp.addon_install.summary", lambda: {})
+    monkeypatch.setattr("tbmcp.profile.list_profiles", lambda: [profile] if profile else [])
+    monkeypatch.setattr("tbmcp.profile.find_profile", lambda *_a, **_k: profile)
+    monkeypatch.setattr("tbmcp.addon_install.summary", lambda: dict(addon_summary or {}))
 
     from tbmcp.ipc import DaemonInfo
 
@@ -204,3 +217,203 @@ def test_returns_nonzero_when_the_bridge_is_genuinely_not_connected(monkeypatch)
     exit_code = cmd_doctor(args)
 
     assert exit_code == 1
+
+
+# ------------------------------------------------- what doctor now has to explain
+#
+# The chain was healthy-looking and broken at the same time: Thunderbird was
+# running, the add-on was dialling in every ~25 s and failing the handshake, and
+# the add-on it had installed (1.2.0) was older than the one in this package. All
+# `doctor` would say was "the add-on has not dialled in yet; try again in a moment".
+
+_ADDON_STATUS = {
+    "writtenAt": "2026-09-08T15:00:00.000Z",
+    "addonVersion": "1.2.0",
+    "capabilities": {"privilegedModules": {"loaded": ["admin", "prefs"]}},
+    "methodCount": 70,
+}
+
+_TRANSPORT = {
+    "state": "connecting",
+    "connecting": True,
+    "attempt": 7,
+    "inFlight": 0,
+    "consecutiveFailures": 7,
+    "lastCloseCode": 1006,
+    "lastCloseAt": "2026-09-08T15:04:00.000Z",
+    "lastWelcomeAt": None,
+    "port": 50284,
+}
+
+_FAILING_HANDSHAKE = {
+    "attempts": 3,
+    "lastAttemptAt": time.time() - 12,
+    "lastOutcome": "no-hello-timeout",
+    "lastCloseCode": 4002,
+    "lastUserAgent": "Thunderbird/155.0",
+    "recentFailures": 3,
+    "recentOutcomes": {"no-hello-timeout": 3},
+    "windowSeconds": 60.0,
+    "recent": [],
+}
+
+
+def _profile(tmp_path, status: dict | None = None):
+    """A real `ThunderbirdProfile` on disk, optionally with the add-on's own report."""
+    profile = ThunderbirdProfile(path=tmp_path, name="default", is_default=True, root=tmp_path)
+    if status is not None:
+        profile.addon_status_file.write_text(json.dumps(status), encoding="utf-8")
+    return profile
+
+
+def _stub_server(monkeypatch, *, connected: bool) -> None:
+    class FakeMCP:
+        async def call_tool(self, name, args):
+            return SimpleNamespace(structured_content={"connected": connected})
+
+    monkeypatch.setattr("tbmcp.server.build_server", lambda settings, *, bridge=None: FakeMCP())
+
+
+def _run_doctor(monkeypatch, argv: list[str], **stubs) -> int:
+    _stub_common(monkeypatch, **stubs)
+    _stub_server(monkeypatch, connected=bool(stubs["bridge_status"].get("connected")))
+    return cmd_doctor(build_parser().parse_args(["doctor", *argv, "--wait", "0"]))
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_the_json_report_compares_the_installed_add_on_with_the_source(
+    monkeypatch, tmp_path, capsys
+):
+    exit_code = _run_doctor(
+        monkeypatch,
+        ["--json"],
+        bridge_status={"connected": False},
+        addon_summary={"addonVersion": "1.3.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, _ADDON_STATUS),
+    )
+
+    report = json.loads(capsys.readouterr().out)
+    assert report["addonVersions"] == {
+        "installed": "1.2.0",
+        "live": None,
+        "source": "1.3.0",
+        "mismatch": True,
+    }
+    assert exit_code == 1
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_an_out_of_date_add_on_is_named_with_its_remedy(monkeypatch, tmp_path, capsys):
+    exit_code = _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={"connected": False},
+        addon_summary={"addonVersion": "1.3.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, _ADDON_STATUS),
+    )
+
+    out = capsys.readouterr().out
+    assert "add-on version (installed)" in out
+    assert "installed add-on is 1.2.0, source is 1.3.0" in out
+    assert "tbmcp install-addon" in out
+    assert exit_code == 1
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_a_working_chain_on_an_older_add_on_is_a_warning_not_a_failure(
+    monkeypatch, tmp_path, capsys
+):
+    """It works, so `ok` stays true — but the user is running code they replaced."""
+    exit_code = _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={
+            "connected": True,
+            "thunderbird": {"addonVersion": "1.2.0", "experiment": True, "app": {}},
+        },
+        addon_summary={"addonVersion": "1.3.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, _ADDON_STATUS),
+    )
+
+    out = capsys.readouterr().out
+    assert "Warning: installed add-on is 1.2.0, source is 1.3.0" in out
+    assert exit_code == 0
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_a_matching_add_on_says_nothing_about_versions(monkeypatch, tmp_path, capsys):
+    exit_code = _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={
+            "connected": True,
+            "thunderbird": {"addonVersion": "1.3.0", "experiment": True, "app": {}},
+        },
+        addon_summary={"addonVersion": "1.3.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, {**_ADDON_STATUS, "addonVersion": "1.3.0"}),
+    )
+
+    out = capsys.readouterr().out
+    assert "Warning" not in out
+    assert exit_code == 0
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_repeated_handshake_failures_replace_the_try_again_in_a_moment_advice(
+    monkeypatch, tmp_path, capsys
+):
+    """The advice that was wrong all morning: the add-on had dialled in dozens of
+    times, so telling the user to wait a moment sent them nowhere."""
+    exit_code = _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={"connected": False, "handshake": _FAILING_HANDSHAKE},
+        addon_summary={"addonVersion": "1.2.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, _ADDON_STATUS),
+    )
+
+    out = capsys.readouterr().out
+    # The diagnosis is a wrapped paragraph, so read it as one flowing sentence.
+    flat = " ".join(out.split())
+    assert "add-on handshakes" in out
+    assert "3 attempts" in out
+    assert "never completed the handshake" in flat
+    assert "try again in a moment" not in flat
+    assert exit_code == 1
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_the_add_ons_own_account_of_the_connection_is_printed(monkeypatch, tmp_path, capsys):
+    """The add-on's side of the same story, from the file it writes itself: without
+    it a reader cannot tell a daemon nobody dialled from an add-on that keeps
+    failing to."""
+    _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={"connected": False},
+        addon_summary={"addonVersion": "1.2.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, {**_ADDON_STATUS, "transport": _TRANSPORT}),
+    )
+
+    out = capsys.readouterr().out
+    assert "add-on transport" in out
+    assert "connecting" in out
+    assert "7 failed attempts" in out
+    assert "1006" in out
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_the_daemon_log_is_named_because_nothing_else_shows_it(monkeypatch, tmp_path, capsys):
+    _run_doctor(
+        monkeypatch,
+        [],
+        bridge_status={"connected": False},
+        addon_summary={"addonVersion": "1.2.0", "thunderbirdRunning": False},
+        profile=_profile(tmp_path),
+    )
+
+    out = capsys.readouterr().out
+    assert "daemon log" in out
+    assert "daemon.log" in out
+    assert "add-on handshakes" in out
+    assert "none since the daemon started" in out

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -435,3 +435,32 @@ def test_a_stale_addon_is_named_even_while_thunderbird_is_closed(monkeypatch, tm
     assert "Thunderbird is not running" in out
     assert "installed add-on is 1.2.0, source is 1.3.0" in out
     assert "tbmcp install-addon" in out
+
+
+@pytest.mark.usefixtures("_clean_tbmcp_env")
+def test_the_daemon_line_reflects_the_daemon_the_probe_started(monkeypatch, tmp_path, capsys):
+    """`doctor` read the advertisement before its probe autostarted a daemon, so the
+    most common first run printed `daemon: not running` directly above
+    `connected: True` — and shipped `daemon.running: false` in --json."""
+    from types import SimpleNamespace
+
+    from tbmcp.ipc import DaemonInfo
+
+    _stub_common(
+        monkeypatch,
+        bridge_status={"connected": True, "thunderbird": {"addonVersion": "1.3.0"}},
+        addon_summary={"addonVersion": "1.3.0", "thunderbirdRunning": True},
+        profile=_profile(tmp_path, {**_ADDON_STATUS, "addonVersion": "1.3.0"}),
+    )
+    _stub_server(monkeypatch, connected=True)
+    # Nothing advertised before the probe; a daemon advertised once it has run.
+    loads = iter([None, SimpleNamespace(pid=4242, port=5151)])
+    monkeypatch.setattr(DaemonInfo, "load", classmethod(lambda cls: next(loads, None)))
+
+    exit_code = cmd_doctor(build_parser().parse_args(["doctor", "--json", "--wait", "0"]))
+
+    report = json.loads(capsys.readouterr().out)
+    assert exit_code == 0
+    assert report["daemon"]["running"] is True
+    assert report["daemon"]["pid"] == 4242
+    assert report["daemon"]["logFile"].endswith("daemon.log")

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -453,9 +453,25 @@ def test_the_daemon_line_reflects_the_daemon_the_probe_started(monkeypatch, tmp_
         profile=_profile(tmp_path, {**_ADDON_STATUS, "addonVersion": "1.3.0"}),
     )
     _stub_server(monkeypatch, connected=True)
-    # Nothing advertised before the probe; a daemon advertised once it has run.
-    loads = iter([None, SimpleNamespace(pid=4242, port=5151)])
-    monkeypatch.setattr(DaemonInfo, "load", classmethod(lambda cls: next(loads, None)))
+    # Nothing is advertised until the probe has run; the advertisement must be read
+    # after it, never before. `probed` flips when the (fake) bridge is asked to
+    # connect, so a read that happens too early sees None.
+    probed = {"done": False}
+
+    def load(cls):
+        return SimpleNamespace(pid=4242, port=5151) if probed["done"] else None
+
+    monkeypatch.setattr(DaemonInfo, "load", classmethod(load))
+    import tbmcp.bridge as bridge_module
+
+    fake_bridge_cls = bridge_module.Bridge
+    original_require = fake_bridge_cls.require_thunderbird
+
+    async def require_and_mark(self, *, wait=0.0):
+        probed["done"] = True
+        return await original_require(self, wait=wait)
+
+    monkeypatch.setattr(fake_bridge_cls, "require_thunderbird", require_and_mark)
 
     exit_code = cmd_doctor(build_parser().parse_args(["doctor", "--json", "--wait", "0"]))
 

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -26,7 +26,7 @@ from websockets.exceptions import ConnectionClosed
 from tbmcp import ipc
 from tbmcp.daemon import Daemon, run_daemon
 from tbmcp.errors import NotConnectedError
-from tbmcp.profile import ThunderbirdProfile
+from tbmcp.profile import BRIDGE_FILE, ThunderbirdProfile
 
 pytestmark = pytest.mark.anyio
 
@@ -327,3 +327,35 @@ class TestHandshakeTelemetry:
                 await daemon._invoke("messages.query", {}, timeout=1, on_progress=None)
 
         assert "never completed the handshake" in caught.value.message
+
+    def test_standing_down_leaves_the_winners_files_alone(self, isolated_state) -> None:
+        """`_cleanup` unlinked both files unconditionally, so a daemon that stood
+        down because it had been superseded deleted the *winner's* pairing file and
+        advertisement — and the add-on was left holding a token nobody listened for."""
+        daemon = _daemon(isolated_state)
+        bridge_file = isolated_state / BRIDGE_FILE
+        bridge_file.write_text(json.dumps({"port": 1, "token": "theirs", "pid": 999_001}))
+        ipc.DaemonInfo(
+            version=ipc.PROTOCOL_VERSION, port=1, token="theirs", pid=999_001, profile=""
+        ).write()
+
+        daemon._cleanup()
+
+        assert bridge_file.is_file(), "deleted the winner's pairing file"
+        assert ipc.DaemonInfo.path().is_file(), "deleted the winner's advertisement"
+
+    def test_a_daemon_still_clears_up_after_itself(self, isolated_state) -> None:
+        daemon = _daemon(isolated_state)
+        daemon._write_bridge_file(51234)
+        ipc.DaemonInfo(
+            version=ipc.PROTOCOL_VERSION,
+            port=1,
+            token="ours",
+            pid=os.getpid(),
+            profile=str(isolated_state),
+        ).write()
+
+        daemon._cleanup()
+
+        assert not (isolated_state / BRIDGE_FILE).exists()
+        assert not ipc.DaemonInfo.path().exists()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -38,6 +38,7 @@ pytestmark = pytest.mark.anyio
 def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path))
     ipc.DaemonInfo.clear()
     yield tmp_path
     ipc.DaemonInfo.clear()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -18,12 +18,15 @@ import json
 import logging
 import os
 import time
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
 
 import pytest
 from websockets.asyncio.client import connect as ws_connect
 from websockets.exceptions import ConnectionClosed
 
 from tbmcp import ipc
+from tbmcp.cli import build_parser, cmd_daemon
 from tbmcp.daemon import Daemon, run_daemon
 from tbmcp.errors import NotConnectedError
 from tbmcp.profile import BRIDGE_FILE, ThunderbirdProfile
@@ -359,3 +362,38 @@ class TestHandshakeTelemetry:
 
         assert not (isolated_state / BRIDGE_FILE).exists()
         assert not ipc.DaemonInfo.path().exists()
+
+
+# ------------------------------------------------------------- the daemon's log
+#
+# The daemon is spawned detached with stdout and stderr on DEVNULL, so until now
+# everything it logged went nowhere: not the handshake failures, not a stand-down,
+# not the reason it exited. `doctor` prints the path this test pins.
+
+
+def test_the_daemon_command_opens_a_log_file_it_can_be_read_back_from(
+    isolated_state, monkeypatch, caplog
+) -> None:
+    async def _run(*_args, **_kwargs) -> int:
+        return 0
+
+    monkeypatch.setattr("tbmcp.daemon.run_daemon", _run)
+    caplog.set_level(logging.INFO)
+    root = logging.getLogger()
+    before = list(root.handlers)
+    try:
+        assert cmd_daemon(build_parser().parse_args(["daemon"])) == 0
+
+        added = [handler for handler in root.handlers if handler not in before]
+        assert len(added) == 1, "exactly one log file handler belongs on the root logger"
+        assert isinstance(added[0], RotatingFileHandler), "an unbounded log fills the disk"
+        log_file = isolated_state / "tbmcp" / "daemon.log"
+        assert Path(added[0].baseFilename) == log_file
+
+        logging.getLogger("tbmcp.daemon").info("the add-on never said hello")
+        added[0].flush()
+        assert "the add-on never said hello" in log_file.read_text(encoding="utf-8")
+    finally:
+        for handler in [h for h in root.handlers if h not in before]:
+            root.removeHandler(handler)
+            handler.close()

--- a/tests/test_daemon.py
+++ b/tests/test_daemon.py
@@ -12,12 +12,21 @@ healthy — which is why they are pinned down as tests rather than left to judge
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
+import json
+import logging
 import os
+import time
 
 import pytest
+from websockets.asyncio.client import connect as ws_connect
+from websockets.exceptions import ConnectionClosed
 
 from tbmcp import ipc
-from tbmcp.daemon import run_daemon
+from tbmcp.daemon import Daemon, run_daemon
+from tbmcp.errors import NotConnectedError
+from tbmcp.profile import ThunderbirdProfile
 
 pytestmark = pytest.mark.anyio
 
@@ -128,8 +137,6 @@ async def test_a_missing_profile_releases_the_lock(isolated_state, monkeypatch) 
 
 def test_supersede_rule(isolated_state, monkeypatch) -> None:
     """The watchdog's decision: stand down when the advertisement names someone else."""
-    from tbmcp.daemon import Daemon
-
     # Nothing advertised: keep running.
     assert Daemon.superseded_by() is None
 
@@ -150,3 +157,173 @@ def test_supersede_rule(isolated_state, monkeypatch) -> None:
         ),
     )
     assert Daemon.superseded_by() == 999_001
+
+
+# ------------------------------------------------------- handshake telemetry
+#
+# The morning this class exists for: thunderbird.exe opened two connections to the
+# add-on port every ~25 s for half an hour, each dying ~10 s later with the HTTP
+# upgrade never completed. The handler never ran, so nothing was logged, nothing was
+# counted, and every reporter could only say "Thunderbird is not connected". These
+# tests drive the real `serve()` the daemon runs — same connection class, same
+# process_request hook — because the whole point is what happens *before* the
+# handler.
+
+
+def _daemon(path) -> Daemon:
+    profile = ThunderbirdProfile(path=path, name="test", is_default=True, root=path)
+    return Daemon(profile, idle_timeout=0)
+
+
+def _hello(token: str, *, protocol: object = ipc.PROTOCOL_VERSION) -> str:
+    return json.dumps(
+        {
+            "t": "hello",
+            "token": token,
+            "protocol": protocol,
+            "addonVersion": "1.3.0",
+            "app": {"name": "Thunderbird", "version": "155.0"},
+            "capabilities": {"experiment": True, "namespaces": ["messages"]},
+        }
+    )
+
+
+async def _settled(daemon: Daemon, predicate, *, timeout: float = 2.0) -> dict:
+    """The summary once it says what the test is waiting for.
+
+    Both ends of a close race: the client is told before the server's handler has
+    finished unwinding, and a connection that never upgrades is only recorded when
+    websockets gives up on it.
+    """
+    deadline = time.monotonic() + timeout
+    while True:
+        summary = daemon.handshakes.summary()
+        if predicate(summary):
+            return summary
+        if time.monotonic() >= deadline:
+            raise AssertionError(f"handshake summary never settled: {summary}")
+        await asyncio.sleep(0.02)
+
+
+class TestHandshakeTelemetry:
+    async def test_a_client_that_never_says_hello_is_recorded(
+        self, isolated_state, monkeypatch
+    ) -> None:
+        monkeypatch.setattr("tbmcp.daemon.HELLO_TIMEOUT", 0.3)
+        daemon = _daemon(isolated_state)
+        async with daemon._addon_server(open_timeout=0.3) as server:
+            port = server.sockets[0].getsockname()[1]
+            async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as ws:
+                with pytest.raises(ConnectionClosed):
+                    await asyncio.wait_for(ws.recv(), timeout=5.0)
+                assert ws.close_code == 4002
+
+        summary = daemon.status()["handshake"]
+        assert summary["lastOutcome"] == "no-hello-timeout"
+        assert summary["recentFailures"] == 1
+
+    async def test_a_stale_token_is_recorded_without_being_logged(
+        self, isolated_state, caplog
+    ) -> None:
+        daemon = _daemon(isolated_state)
+        with caplog.at_level(logging.DEBUG):
+            async with daemon._addon_server(open_timeout=0.3) as server:
+                port = server.sockets[0].getsockname()[1]
+                async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as ws:
+                    await ws.send(_hello("not-the-token"))
+                    with pytest.raises(ConnectionClosed):
+                        await asyncio.wait_for(ws.recv(), timeout=5.0)
+                    assert ws.close_code == 4001
+
+        summary = daemon.handshakes.summary()
+        assert summary["lastOutcome"] == "bad-token"
+        assert daemon.addon_token not in caplog.text, "a token must never reach a log"
+
+    async def test_a_non_numeric_protocol_is_a_mismatch_not_a_crash(
+        self, isolated_state, caplog
+    ) -> None:
+        """`int(hello["protocol"])` on a string raised straight out of the handler:
+        websockets logged a traceback and the add-on learnt nothing."""
+        daemon = _daemon(isolated_state)
+        with caplog.at_level(logging.DEBUG):
+            async with daemon._addon_server(open_timeout=0.3) as server:
+                port = server.sockets[0].getsockname()[1]
+                async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as ws:
+                    await ws.send(_hello(daemon.addon_token, protocol="x"))
+                    with pytest.raises(ConnectionClosed):
+                        await asyncio.wait_for(ws.recv(), timeout=5.0)
+                    assert ws.close_code == 4002
+
+        assert daemon.handshakes.summary()["lastOutcome"] == "protocol-mismatch"
+        assert "Traceback" not in caplog.text
+
+    async def test_a_good_hello_is_welcomed_and_then_disconnects(self, isolated_state) -> None:
+        daemon = _daemon(isolated_state)
+        async with daemon._addon_server(open_timeout=0.3) as server:
+            port = server.sockets[0].getsockname()[1]
+            async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as ws:
+                await ws.send(_hello(daemon.addon_token))
+                welcome = json.loads(await asyncio.wait_for(ws.recv(), timeout=5.0))
+                assert welcome["t"] == "welcome"
+                assert daemon.status()["connected"] is True
+
+            summary = await _settled(daemon, lambda s: s["lastOutcome"] == "disconnected")
+
+        assert summary["lastCloseCode"] == 1000
+        assert summary["recentFailures"] == 0
+        assert summary["recent"][-1]["addonVersion"] == "1.3.0"
+
+    async def test_the_session_that_is_replaced_reads_as_superseded(self, isolated_state) -> None:
+        daemon = _daemon(isolated_state)
+        async with daemon._addon_server(open_timeout=0.3) as server:
+            port = server.sockets[0].getsockname()[1]
+            async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as first:
+                await first.send(_hello(daemon.addon_token))
+                await asyncio.wait_for(first.recv(), timeout=5.0)
+
+                async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as second:
+                    await second.send(_hello(daemon.addon_token))
+                    await asyncio.wait_for(second.recv(), timeout=5.0)
+                    with pytest.raises(ConnectionClosed):
+                        await asyncio.wait_for(first.recv(), timeout=5.0)
+                    assert first.close_code == 1012
+
+                    summary = await _settled(
+                        daemon, lambda s: s["recent"][0]["outcome"] == "superseded"
+                    )
+
+        assert [row["outcome"] for row in summary["recent"]] == ["superseded", "welcomed"]
+
+    async def test_a_connection_that_never_upgrades_is_recorded(self, isolated_state) -> None:
+        """The one the handler cannot see: the socket opens, nothing is sent, and
+        websockets drops it when `open_timeout` expires without ever calling us."""
+        daemon = _daemon(isolated_state)
+        async with daemon._addon_server(open_timeout=0.3) as server:
+            port = server.sockets[0].getsockname()[1]
+            _reader, writer = await asyncio.open_connection("127.0.0.1", port)
+            try:
+                summary = await _settled(daemon, lambda s: s["lastOutcome"] == "no-upgrade")
+            finally:
+                writer.close()
+                with contextlib.suppress(OSError):
+                    await writer.wait_closed()
+
+        assert summary["recentFailures"] == 1
+
+    async def test_a_failing_handshake_reaches_the_caller_of_a_tool(
+        self, isolated_state, monkeypatch
+    ) -> None:
+        """The payoff: every "not connected" now carries why, instead of leaving the
+        model to guess between "start Thunderbird" and a broken add-on."""
+        monkeypatch.setattr("tbmcp.daemon.HELLO_TIMEOUT", 0.3)
+        daemon = _daemon(isolated_state)
+        async with daemon._addon_server(open_timeout=0.3) as server:
+            port = server.sockets[0].getsockname()[1]
+            async with ws_connect(f"ws://127.0.0.1:{port}/tbmcp") as ws:
+                with pytest.raises(ConnectionClosed):
+                    await asyncio.wait_for(ws.recv(), timeout=5.0)
+
+            with pytest.raises(NotConnectedError) as caught:
+                await daemon._invoke("messages.query", {}, timeout=1, on_progress=None)
+
+        assert "never completed the handshake" in caught.value.message

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -8,6 +8,7 @@ from a broken install.
 
 from __future__ import annotations
 
+from tbmcp.daemon import error_payload
 from tbmcp.errors import (
     BlockedError,
     NotConnectedError,
@@ -63,3 +64,38 @@ def test_usage_errors_read_as_instructions() -> None:
     error = UsageError("subject is required", hint="pass subject")
     assert "subject is required" in str(error)
     assert "pass subject" in str(error)
+
+
+# --------------------------------------------------------- relaying, without echoes
+
+#: What the add-on puts on the wire for a refused delete.
+WIRE = {
+    "kind": "blocked",
+    "code": "NEEDS_CONSENT",
+    "message": "refusing to delete 40 messages",
+    "needs": ["confirm=true"],
+}
+
+
+def test_relaying_an_error_leaves_it_unchanged() -> None:
+    """The daemon used to serialise `str(exc)`, which already renders the code and the
+    `needs` list into the text for humans. Every hop therefore appended them again, and
+    a caller saw "... [NOT_CONNECTED] [NOT_CONNECTED]". Relaying has to be idempotent.
+    """
+    once = error_payload(from_wire("mail_delete", WIRE))
+    assert once == WIRE
+    twice = error_payload(from_wire("mail_delete", once))
+    assert twice == WIRE
+
+
+def test_a_twice_relayed_error_still_reads_once() -> None:
+    rebuilt = from_wire("mail_delete", error_payload(from_wire("mail_delete", WIRE)))
+    text = str(rebuilt)
+    assert text.count("requires:") == 1
+    assert text.count("NEEDS_CONSENT") == 1
+
+
+def test_an_untyped_failure_keeps_its_text() -> None:
+    """Anything the daemon did not raise deliberately is still worth relaying: a hidden
+    JSON-RPC error looks like a hang from the user's side."""
+    assert error_payload(RuntimeError("x")) == {"kind": "internal", "code": None, "message": "x"}

--- a/tests/test_handshake.py
+++ b/tests/test_handshake.py
@@ -1,0 +1,266 @@
+"""Why the add-on never got welcomed, recorded where every reporter can read it.
+
+The morning this exists for: thunderbird.exe opened two connections to the add-on
+port every ~25 s for half an hour, each dying ~10 s later without ever finishing the
+HTTP upgrade. `tb_status` said "ask the user to start Thunderbird" and `doctor` said
+"try again in a moment", because nothing anywhere recorded that the add-on had been
+*trying*. This module is that record, so both reporters can say what is happening.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from tbmcp.handshake import FAILED_BEFORE_HELLO, HandshakeLog, describe_handshake
+
+
+class Clock:
+    """An injected clock: the window arithmetic must not depend on wall time."""
+
+    def __init__(self, now: float) -> None:
+        self.now = now
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+class Conn:
+    """Stands in for a `ServerConnection`: the log keys on identity and reads the
+    peer port off the object, in the shape websockets exposes it."""
+
+    def __init__(self, port: int | None = None) -> None:
+        self.remote_address = ("127.0.0.1", port) if port is not None else None
+
+
+# ------------------------------------------------------------------ HandshakeLog
+
+
+def test_one_attempt_per_connection_however_often_it_is_opened() -> None:
+    log = HandshakeLog(clock=Clock(1000.0))
+    conn = Conn(51234)
+
+    first = log.opened(conn)
+
+    assert log.opened(conn) is first, "a second event on one connection is one attempt"
+    assert first.peer_port == 51234
+    assert log.summary()["attempts"] == 1
+
+
+def test_the_outcome_an_attempt_lands_on_first_is_the_one_that_sticks() -> None:
+    """`connection_lost` fires for a rejected connection too, so a failure that has
+    already been diagnosed must not be relabelled by the generic hook behind it."""
+    log = HandshakeLog(clock=Clock(1000.0))
+    conn = Conn(1)
+    log.opened(conn)
+
+    log.resolve(conn, "bad-token", close_code=4001)
+    log.resolve(conn, "no-upgrade")
+    log.resolve(conn, "disconnected", close_code=1000)
+
+    summary = log.summary()
+    assert summary["lastOutcome"] == "bad-token"
+    assert summary["lastCloseCode"] == 4001
+    assert summary["recentFailures"] == 1
+
+
+def test_a_welcomed_session_only_moves_on_to_disconnected_or_superseded() -> None:
+    log = HandshakeLog(clock=Clock(1000.0))
+    conn = Conn(1)
+    log.opened(conn)
+    log.resolve(conn, "welcomed", addon_version="1.3.0")
+
+    log.resolve(conn, "no-upgrade")
+    assert log.summary()["lastOutcome"] == "welcomed", "a working session is not a failure"
+
+    log.resolve(conn, "disconnected", close_code=1000)
+    summary = log.summary()
+    assert summary["lastOutcome"] == "disconnected"
+    assert summary["lastCloseCode"] == 1000
+    assert summary["recentFailures"] == 0
+
+
+def test_superseded_is_final_so_the_handler_behind_it_cannot_relabel_it() -> None:
+    """The replaced session's own `finally` runs after it is closed with 1012; it
+    reporting "disconnected" would hide the fact that we replaced it."""
+    log = HandshakeLog(clock=Clock(1000.0))
+    conn = Conn(1)
+    log.opened(conn)
+    log.resolve(conn, "welcomed")
+
+    log.resolve(conn, "superseded", close_code=1012)
+    log.resolve(conn, "disconnected", close_code=1012)
+
+    assert log.summary()["lastOutcome"] == "superseded"
+
+
+def test_every_outcome_that_fails_before_the_hello_counts_as_a_failure() -> None:
+    log = HandshakeLog(clock=Clock(1000.0))
+    for index, outcome in enumerate(sorted(FAILED_BEFORE_HELLO)):
+        conn = Conn(index)
+        log.opened(conn)
+        log.resolve(conn, outcome)
+
+    assert log.summary()["recentFailures"] == len(FAILED_BEFORE_HELLO)
+
+
+def test_a_failure_falls_out_of_the_window_once_it_is_old_enough() -> None:
+    clock = Clock(1000.0)
+    log = HandshakeLog(clock=clock, window=60.0)
+    old = Conn(1)
+    log.opened(old)
+    log.resolve(old, "no-hello-timeout", close_code=4002)
+
+    clock.advance(61.0)
+    fresh = Conn(2)
+    log.opened(fresh)
+    log.resolve(fresh, "no-upgrade")
+
+    summary = log.summary()
+    assert summary["attempts"] == 2
+    assert summary["recentFailures"] == 1, "the 61s-old failure is not recent"
+    assert summary["recentOutcomes"] == {"no-upgrade": 1}
+    assert summary["windowSeconds"] == 60.0
+
+
+def test_the_ring_buffer_caps_what_is_kept_but_not_what_is_counted() -> None:
+    """A reconnect every 25 s fills any buffer in minutes; "attempts" has to keep
+    counting or the doctor line understates a half-hour outage."""
+    log = HandshakeLog(maxlen=5, clock=Clock(1000.0))
+    for index in range(12):
+        conn = Conn(index)
+        log.opened(conn)
+        log.resolve(conn, "no-upgrade")
+
+    summary = log.summary()
+    assert summary["attempts"] == 12
+    assert len(summary["recent"]) == 5
+    assert summary["recent"][-1]["peerPort"] == 11
+
+
+def test_the_upgrade_request_names_who_dialled_in() -> None:
+    log = HandshakeLog(clock=Clock(1000.0))
+    conn = Conn(51234)
+    log.opened(conn)
+
+    log.note_request(conn, path="/tbmcp", origin=None, user_agent="Thunderbird/155.0")
+    log.resolve(conn, "no-hello-timeout", close_code=4002)
+
+    summary = log.summary()
+    assert summary["lastUserAgent"] == "Thunderbird/155.0"
+    # The path is the one thing that separates "the TCP connection opened and
+    # nothing was ever sent" from "it asked for our endpoint and then died".
+    assert summary["recent"][-1]["detail"] == "/tbmcp"
+
+
+def test_a_failure_is_logged_with_the_facts_a_reader_needs(caplog) -> None:
+    clock = Clock(1000.0)
+    log = HandshakeLog(clock=clock)
+    conn = Conn(51234)
+    log.opened(conn)
+    log.note_request(conn, path="/tbmcp", origin=None, user_agent="Thunderbird/155.0")
+    clock.advance(10.0)
+
+    with caplog.at_level(logging.DEBUG, logger="tbmcp.handshake"):
+        log.resolve(conn, "no-hello-timeout", close_code=4002)
+
+    assert [record.levelname for record in caplog.records] == ["WARNING"]
+    assert "no-hello-timeout" in caplog.text
+    assert "51234" in caplog.text
+    assert "Thunderbird/155.0" in caplog.text
+    assert "10.0s" in caplog.text
+
+
+def test_a_welcome_is_news_but_not_a_warning(caplog) -> None:
+    log = HandshakeLog(clock=Clock(1000.0))
+    conn = Conn(1)
+    log.opened(conn)
+
+    with caplog.at_level(logging.DEBUG, logger="tbmcp.handshake"):
+        log.resolve(conn, "welcomed", addon_version="1.3.0")
+
+    assert [record.levelname for record in caplog.records] == ["INFO"]
+    assert "1.3.0" in caplog.text
+
+
+# ------------------------------------------------------------- describe_handshake
+
+
+def _summary(**overrides: object) -> dict:
+    """A summary as the daemon would have serialised it, 12 s after the last try."""
+    base = {
+        "attempts": 3,
+        "lastAttemptAt": time.time() - 12,
+        "lastOutcome": "no-hello-timeout",
+        "lastCloseCode": 4002,
+        "lastUserAgent": "Thunderbird/155.0",
+        "recentFailures": 3,
+        "recentOutcomes": {"no-hello-timeout": 3},
+        "windowSeconds": 60.0,
+        "recent": [],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_nothing_to_diagnose_reads_as_no_diagnosis() -> None:
+    assert describe_handshake(None) is None
+    assert describe_handshake(_summary(recentFailures=0, recentOutcomes={})) is None
+
+
+def test_the_diagnosis_names_the_symptom_and_every_remedy() -> None:
+    text = describe_handshake(_summary())
+
+    assert text is not None
+    assert "3 times in the last 60 s" in text
+    assert "no-hello-timeout" in text
+    assert "12 s ago" in text
+    assert "Restart Thunderbird" in text
+    assert "Error Console" in text
+    assert "[tbmcp]" in text
+    assert "tbmcp install-addon" in text
+
+
+def test_one_failure_is_reported_as_one_time() -> None:
+    text = describe_handshake(_summary(recentFailures=1, recentOutcomes={"bad-hello": 1}))
+
+    assert text is not None and "1 time in the last 60 s" in text
+
+
+@pytest.mark.parametrize(
+    ("outcome", "sentence"),
+    [
+        ("no-upgrade", "the WebSocket upgrade never completed"),
+        ("bad-token", "stale token"),
+        ("protocol-mismatch", "different protocol version"),
+    ],
+)
+def test_each_outcome_that_has_its_own_cause_says_so(outcome: str, sentence: str) -> None:
+    text = describe_handshake(_summary(lastOutcome=outcome, recentOutcomes={outcome: 3}))
+
+    assert text is not None and sentence in text
+
+
+def test_the_diagnosis_quotes_the_last_failure_not_a_later_success() -> None:
+    """A flapping add-on gets welcomed between failures. Naming the connection that
+    worked would send the reader looking in the wrong place."""
+    now = time.time()
+    text = describe_handshake(
+        _summary(
+            lastOutcome="disconnected",
+            lastAttemptAt=now - 1,
+            recent=[
+                {"at": now - 30, "outcome": "bad-token"},
+                {"at": now - 1, "outcome": "disconnected"},
+            ],
+        )
+    )
+
+    assert text is not None
+    assert "bad-token" in text
+    assert "stale token" in text

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -265,3 +265,59 @@ async def _advertised_daemon() -> ipc.DaemonInfo:
             return info
         await asyncio.sleep(0.05)
     raise AssertionError("the daemon never advertised itself")
+
+
+class _StubWriter:
+    """Just enough writer for what the read loop does on its way out."""
+
+    def __init__(self) -> None:
+        self._closing = False
+
+    def close(self) -> None:
+        self._closing = True
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+
+def _stub_bridge() -> tuple[Bridge, _StubWriter]:
+    """A bridge holding a reader that cannot frame much, and a writer we can watch."""
+    bridge = Bridge(autostart=False)
+    bridge._reader = asyncio.StreamReader(limit=1024)
+    writer = _StubWriter()
+    bridge._writer = writer  # type: ignore[assignment]
+    return bridge, writer
+
+
+def _in_flight(bridge: Bridge) -> asyncio.Future:
+    future = asyncio.get_running_loop().create_future()
+    bridge._pending[1] = future
+    return future
+
+
+async def test_an_oversized_frame_fails_the_call_by_name() -> None:
+    """DISCONNECTED sends whoever reads it looking at the daemon; the size is the one
+    thing they need to know."""
+    bridge, _ = _stub_bridge()
+    pending = _in_flight(bridge)
+    bridge._reader.feed_data(b"x" * 4096)  # no newline, well past the buffer
+    await bridge._read_loop()
+    assert pending.exception().code == "TOO_LARGE"
+
+
+async def test_a_peer_that_hangs_up_still_reads_as_a_disconnect() -> None:
+    bridge, _ = _stub_bridge()
+    pending = _in_flight(bridge)
+    bridge._reader.feed_eof()
+    await bridge._read_loop()
+    assert pending.exception().code == "DISCONNECTED"
+
+
+async def test_the_read_loop_closes_the_writer_it_can_no_longer_read_for() -> None:
+    """`_ensure` judges the connection by the writer alone. Left open after the reader
+    died, the next call wrote into a socket nobody was reading and then waited out its
+    whole timeout — one unreadable frame wedged the bridge for good."""
+    bridge, writer = _stub_bridge()
+    bridge._reader.feed_eof()
+    await bridge._read_loop()
+    assert writer.is_closing()

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -1,14 +1,20 @@
-"""Daemon advertisement and line framing."""
+"""Daemon advertisement, line framing, and the size a frame is allowed to be."""
 
 from __future__ import annotations
 
+import asyncio
+import contextlib
 import json
 import os
+import time
 
 import pytest
 
 from tbmcp import ipc
+from tbmcp.bridge import Bridge
+from tbmcp.daemon import Daemon
 from tbmcp.errors import TransportError
+from tbmcp.profile import ThunderbirdProfile
 
 pytestmark = pytest.mark.anyio
 
@@ -121,3 +127,141 @@ async def test_write_then_read_round_trip() -> None:
     frame = {"t": "req", "id": 7, "method": "prefs.get", "params": {"name": "a.b"}}
     await ipc.write_message(writer, frame)
     assert await ipc.read_message(_Reader(b"".join(writer.chunks))) == frame
+
+
+# ------------------------------------------------------------------ the size ceiling
+#
+# `MAX_LINE` named the ceiling, but neither end passed it to asyncio, so what a frame
+# really had to fit in was asyncio's 64 KiB default. Past it `readline()` raised a bare
+# `ValueError`, the bridge's read loop died, and a wide search result — 200 hits, about
+# 64 KB of JSON — wedged the connection for every later call.
+
+
+async def test_read_message_reports_a_frame_the_buffer_cannot_hold() -> None:
+    """Unhandled, that `ValueError` failed every pending call as a plain disconnect,
+    which points the reader at the network instead of at the size."""
+
+    async def flood(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        with contextlib.suppress(OSError):
+            writer.write(b"x" * 300_000)  # no newline, so it can never be framed
+            await writer.drain()
+        writer.close()
+
+    async with await asyncio.start_server(flood, host="127.0.0.1", port=0) as server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port, limit=1024)
+        try:
+            with pytest.raises(TransportError) as caught:
+                await ipc.read_message(reader)
+        finally:
+            writer.close()
+    assert caught.value.code == "TOO_LARGE"
+
+
+async def test_a_large_frame_survives_when_both_ends_agree_on_the_limit() -> None:
+    frame = {"t": "res", "id": 1, "ok": True, "result": {"body": "m" * 200_000}}
+
+    async def send_one(_reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        with contextlib.suppress(OSError):
+            await ipc.write_message(writer, frame)
+        writer.close()
+
+    async with await asyncio.start_server(
+        send_one, host="127.0.0.1", port=0, limit=ipc.MAX_LINE
+    ) as server:
+        port = server.sockets[0].getsockname()[1]
+        reader, writer = await asyncio.open_connection("127.0.0.1", port, limit=ipc.MAX_LINE)
+        try:
+            assert await ipc.read_message(reader) == frame
+        finally:
+            writer.close()
+
+
+@pytest.fixture
+def isolated_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
+    monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    ipc.DaemonInfo.clear()
+    yield tmp_path
+    ipc.DaemonInfo.clear()
+
+
+async def test_a_large_result_reaches_the_caller(isolated_state) -> None:
+    """The live failure, end to end: 200 search hits came back, the bridge's reader
+    gave up mid-frame, and the call — plus every other one in flight — died as
+    DISCONNECTED."""
+    result = {"messages": [{"subject": "invoice", "preview": "x" * 1000} for _ in range(200)]}
+
+    async def daemon(reader: asyncio.StreamReader, writer: asyncio.StreamWriter) -> None:
+        with contextlib.suppress(Exception):
+            while True:
+                message = await ipc.read_message(reader)
+                if message is None:
+                    return
+                if message.get("t") == "auth":
+                    await ipc.write_message(writer, {"t": "ready", "id": message["id"]})
+                    continue
+                await ipc.write_message(
+                    writer, {"t": "res", "id": message["id"], "ok": True, "result": result}
+                )
+
+    async with await asyncio.start_server(
+        daemon, host="127.0.0.1", port=0, limit=ipc.MAX_LINE
+    ) as server:
+        ipc.DaemonInfo(
+            version=ipc.PROTOCOL_VERSION,
+            port=server.sockets[0].getsockname()[1],
+            token="t",
+            pid=os.getpid(),
+            profile="",
+        ).write()
+        bridge = Bridge(autostart=False)
+        try:
+            # `daemon.status` is answered by the daemon itself, so nothing waits for
+            # Thunderbird to attach.
+            assert await bridge.call("daemon.status", timeout=10.0) == result
+        finally:
+            await bridge.close()
+
+
+async def test_a_large_request_reaches_the_daemon(isolated_state) -> None:
+    """The other direction: a mail_send carrying an attachment is a big frame too."""
+    profile = ThunderbirdProfile(
+        path=isolated_state, name="test", is_default=True, root=isolated_state
+    )
+    daemon = Daemon(profile, idle_timeout=0)
+    running = asyncio.create_task(daemon.run())
+    try:
+        info = await _advertised_daemon()
+        reader, writer = await asyncio.open_connection("127.0.0.1", info.port, limit=ipc.MAX_LINE)
+        try:
+            await ipc.write_message(writer, {"t": "auth", "id": 1, "token": info.token})
+            ready = await asyncio.wait_for(ipc.read_message(reader), timeout=5.0)
+            assert ready is not None and ready["t"] == "ready"
+            await ipc.write_message(
+                writer,
+                {
+                    "t": "req",
+                    "id": 2,
+                    "method": "daemon.status",
+                    "params": {"attachment": "p" * 200_000},
+                    "timeout": 5.0,
+                },
+            )
+            reply = await asyncio.wait_for(ipc.read_message(reader), timeout=5.0)
+            assert reply is not None and reply["ok"], reply
+        finally:
+            writer.close()
+    finally:
+        daemon._stop.set()
+        await asyncio.wait_for(running, timeout=10.0)
+
+
+async def _advertised_daemon() -> ipc.DaemonInfo:
+    deadline = time.monotonic() + 10.0
+    while time.monotonic() < deadline:
+        info = ipc.DaemonInfo.load()
+        if info is not None:
+            return info
+        await asyncio.sleep(0.05)
+    raise AssertionError("the daemon never advertised itself")

--- a/tests/test_ipc.py
+++ b/tests/test_ipc.py
@@ -22,6 +22,7 @@ pytestmark = pytest.mark.anyio
 def test_daemon_info_round_trip(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path))
     info = ipc.DaemonInfo(
         version=ipc.PROTOCOL_VERSION,
         port=51234,
@@ -42,6 +43,7 @@ def test_a_dead_pid_is_treated_as_no_daemon(tmp_path, monkeypatch) -> None:
     """Otherwise every `serve` would try to talk to a port nobody is listening on."""
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path))
     ipc.DaemonInfo(
         version=ipc.PROTOCOL_VERSION, port=1, token="x", pid=0x7FFFFFFF, profile=""
     ).write()
@@ -51,6 +53,7 @@ def test_a_dead_pid_is_treated_as_no_daemon(tmp_path, monkeypatch) -> None:
 def test_a_wrong_protocol_version_is_ignored(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path))
     ipc.DaemonInfo(
         version=ipc.PROTOCOL_VERSION + 99, port=1, token="x", pid=os.getpid(), profile=""
     ).write()
@@ -60,6 +63,7 @@ def test_a_wrong_protocol_version_is_ignored(tmp_path, monkeypatch) -> None:
 def test_corrupt_advertisement_is_ignored(tmp_path, monkeypatch) -> None:
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path))
     ipc.DaemonInfo.path().write_text("{not json", encoding="utf-8")
     assert ipc.DaemonInfo.load() is None
 
@@ -181,6 +185,7 @@ async def test_a_large_frame_survives_when_both_ends_agree_on_the_limit() -> Non
 def isolated_state(tmp_path, monkeypatch):
     monkeypatch.setenv("LOCALAPPDATA", str(tmp_path))
     monkeypatch.setenv("XDG_STATE_HOME", str(tmp_path))
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path))
     ipc.DaemonInfo.clear()
     yield tmp_path
     ipc.DaemonInfo.clear()
@@ -321,3 +326,13 @@ async def test_the_read_loop_closes_the_writer_it_can_no_longer_read_for() -> No
     bridge._reader.feed_eof()
     await bridge._read_loop()
     assert writer.is_closing()
+
+
+def test_state_dir_honours_an_explicit_override_on_every_platform(tmp_path, monkeypatch):
+    """macOS reads no environment variable at all, so a test that pointed
+    LOCALAPPDATA/XDG_STATE_HOME at a temp dir still wrote into the runner's real
+    ~/Library — which is how the daemon-log test failed on the macOS runner only.
+    One explicit override, honoured everywhere, is what CI and tests need."""
+    monkeypatch.setenv("TBMCP_STATE_DIR", str(tmp_path / "override"))
+    assert ipc.state_dir() == tmp_path / "override" / "tbmcp"
+    assert (tmp_path / "override" / "tbmcp").is_dir()

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -7,6 +7,7 @@ otherwise only visible once a real client refuses to load the server.
 from __future__ import annotations
 
 import pytest
+from mcp import Client
 
 from tbmcp.config import ALL_TOOLSETS, DEFAULT_TOOLSETS, Settings, parse_toolsets
 from tbmcp.server import build_server
@@ -136,3 +137,41 @@ def test_parse_toolsets() -> None:
     assert parse_toolsets("settings,mail") == ("mail", "settings")
     with pytest.raises(SystemExit):
         parse_toolsets("nonsense")
+
+
+# ------------------------------------------------------- what a failure looks like
+
+
+def _mail_server(bridge):
+    return build_server(Settings().merged_with(toolsets=("mail",)), bridge=bridge)
+
+
+def _text(result) -> str:
+    return " ".join(getattr(block, "text", "") for block in result.content)
+
+
+async def test_a_deliberate_error_reaches_the_model(fake_bridge) -> None:
+    """The whole point of a `UsageError` is the instruction it carries.
+
+    The SDK withholds the text of anything it reads as a crash — under mcp >= 2.1 the
+    model is told "Error executing tool <name>" and nothing else — so this only holds
+    while the registrar re-raises our failures as the SDK's own `ToolError`.
+    """
+    bridge = fake_bridge()
+    async with Client(_mail_server(bridge)) as client:
+        result = await client.call_tool("mail_search", {})
+    assert result.is_error
+    text = _text(result)
+    assert "Give at least one filter" in text
+    assert "Error executing tool mail_search: Error executing tool" not in text, text
+
+
+async def test_a_blocked_error_names_what_would_unblock_it_once(fake_bridge) -> None:
+    bridge = fake_bridge()
+    async with Client(_mail_server(bridge)) as client:
+        result = await client.call_tool("mail_delete", {"message_ids": [42]})
+    assert result.is_error
+    text = _text(result)
+    assert "confirm=true" in text
+    assert text.count("requires:") == 1, text
+    assert "Error executing tool mail_delete: Error executing tool" not in text, text

--- a/tests/test_smoke_search.py
+++ b/tests/test_smoke_search.py
@@ -1,0 +1,217 @@
+"""The pure parts of `tools/smoke_search.py`.
+
+The script itself needs a live Thunderbird, but everything it decides before it
+asks a question — which folder is worth searching, which word to search for, what
+a failed call means, whether a cursor walk lost a page — is ordinary code, and it
+is the part that silently ruins an acceptance run when it is wrong.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+from typing import Any
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_script():
+    """Import `tools/smoke_search.py`, which is a script and not a package module."""
+    spec = importlib.util.spec_from_file_location(
+        "smoke_search", ROOT / "tools" / "smoke_search.py"
+    )
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+smoke = _load_script()
+
+
+class FakeBlock:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class FakeResult:
+    """What `mcp.Client.call_tool` hands back, minus everything unused here."""
+
+    def __init__(
+        self,
+        *,
+        is_error: bool = False,
+        text: str = "",
+        structured: dict[str, Any] | None = None,
+    ) -> None:
+        self.is_error = is_error
+        self.content = [FakeBlock(text)] if text else []
+        self.structured_content = structured if structured is not None else {}
+
+
+# --------------------------------------------------------------- corpus discovery
+
+FOLDERS = [
+    {"id": "account1://", "name": "Local Folders", "isRoot": True},
+    {"id": "account1://Inbox", "name": "Inbox", "totalMessageCount": 195},
+    {"id": "account1://Archive", "name": "Archive", "totalMessageCount": 40},
+    {"id": "account2://Junk", "name": "Junk", "totalMessageCount": 4},
+    {"id": "account1://Saved", "name": "Saved", "isVirtual": True, "totalMessageCount": 900},
+]
+
+
+def test_biggest_folder_takes_the_fullest_real_folder():
+    folder = smoke.biggest_folder(FOLDERS)
+    assert folder is not None
+    assert folder["id"] == "account1://Inbox"
+
+
+def test_biggest_folder_skips_a_saved_search():
+    """A virtual folder counts messages it does not hold, and cannot be paged."""
+    assert smoke.biggest_folder(FOLDERS)["id"] != "account1://Saved"
+
+
+def test_biggest_folder_gives_up_when_nothing_is_big_enough():
+    small = [{"id": "account1://Inbox", "totalMessageCount": 19}]
+    assert smoke.biggest_folder(small) is None
+    assert smoke.biggest_folder([{"id": "account1://Inbox"}]) is None
+
+
+MESSAGES = [
+    {"id": 1, "subject": "Re: teklif dosyası"},
+    {"id": 2, "subject": "Fwd: Teklif revizyonu"},
+    {"id": 3, "subject": "teklif — son hali"},
+    {"id": 4, "subject": "teklif kabul edildi"},
+    {"id": 5, "subject": "yeni bir konu"},
+]
+
+
+def test_common_term_picks_the_word_the_most_subjects_share():
+    assert smoke.common_term(MESSAGES) == "teklif"
+
+
+def test_common_term_keeps_the_spelling_it_saw():
+    """Case is part of the term: the live check searches for exactly this string."""
+    shouty = [{"subject": f"WEEKLY report {n}"} for n in range(3)]
+    assert smoke.common_term(shouty) == "WEEKLY"
+
+
+def test_common_term_ignores_short_words_and_rare_ones():
+    thin = [
+        {"subject": "one two invoice"},
+        {"subject": "one two receipt"},
+        {"subject": "one two summary"},
+    ]
+    # "one"/"two" are under four letters; nothing else reaches three subjects.
+    assert smoke.common_term(thin) is None
+
+
+def test_common_term_counts_subjects_not_repeats():
+    """A word said four times in one subject is still one subject."""
+    repeated = [{"subject": "invoice invoice invoice invoice"}, {"subject": "invoice again"}]
+    assert smoke.common_term(repeated) is None
+
+
+# ------------------------------------------------------------------- check helper
+
+
+def test_check_turns_a_tool_error_into_a_failure_carrying_its_text(capsys):
+    report = smoke.Report()
+    payload = report.check("mail_search subject", FakeResult(is_error=True, text="no such folder"))
+    assert payload is None
+    assert report.failures == ["mail_search subject"]
+    printed = capsys.readouterr().out
+    assert "FAIL" in printed
+    assert "no such folder" in printed
+
+
+def test_check_returns_the_payload_when_the_call_worked(capsys):
+    report = smoke.Report()
+    payload = report.check("mail_search subject", FakeResult(structured={"count": 5}), "5 hits")
+    assert payload == {"count": 5}
+    assert report.failures == []
+    assert "PASS" in capsys.readouterr().out
+
+
+def test_check_fails_when_the_verdict_says_so(capsys):
+    report = smoke.Report()
+    result = FakeResult(structured={"count": 0})
+    payload = report.check("mail_search subject", result, verify=lambda got: "nothing matched")
+    assert payload is None
+    assert report.failures == ["mail_search subject"]
+    assert "nothing matched" in capsys.readouterr().out
+
+
+def test_an_error_with_no_text_still_says_something(capsys):
+    report = smoke.Report()
+    report.check("search_global ranked", FakeResult(is_error=True))
+    assert report.failures == ["search_global ranked"]
+    assert capsys.readouterr().out.strip() != ""
+
+
+def test_a_skip_is_not_a_failure(capsys):
+    report = smoke.Report()
+    report.skip("search_global ranked", "the index has no hits for this term")
+    assert report.failures == []
+    assert "SKIP" in capsys.readouterr().out
+
+
+# ------------------------------------------------------------------ paging checks
+
+
+def test_paging_gap_is_silent_when_the_walk_matches_one_page():
+    assert smoke.paging_gap([1, 2, 3, 4], [1, 2, 3, 4]) is None
+
+
+def test_paging_gap_names_a_skipped_page():
+    """The 1.2.0 bug: a limit that stopped mid-page dropped the rest of it."""
+    walked = [1, 2, 3, 101, 102, 103]
+    straight = list(range(1, 13))
+    problem = smoke.paging_gap(walked, straight)
+    assert problem is not None
+    assert "9 missing" in problem
+
+
+def test_paging_gap_reports_ids_the_walk_invented():
+    problem = smoke.paging_gap([1, 2, 99], [1, 2, 3])
+    assert problem is not None
+    assert "99" in problem
+
+
+def test_paging_gap_notices_reordering():
+    problem = smoke.paging_gap([2, 1], [1, 2])
+    assert problem is not None
+    assert "order" in problem
+
+
+# ----------------------------------------------------------------- folder id sanity
+
+
+def test_invalid_folder_ids_accepts_ids_the_profile_knows():
+    items = [{"folderId": "account1://Inbox"}, {"folderId": "account1://Archive"}]
+    assert smoke.invalid_folder_ids(items, {"account1://Inbox", "account1://Archive"}) == []
+
+
+def test_invalid_folder_ids_reports_anything_unrecognisable():
+    items = [{"folderId": None}, {"folderId": "Inbox"}, {"folderId": "account9://Nope"}]
+    bad = smoke.invalid_folder_ids(items, {"account1://Inbox"})
+    assert len(bad) == 3
+    assert any("account9://Nope" in entry for entry in bad)
+
+
+def test_invalid_folder_ids_falls_back_to_shape_without_a_folder_list():
+    items = [{"folderId": "account9://Nope"}]
+    assert smoke.invalid_folder_ids(items, None) == []
+
+
+@pytest.mark.parametrize("dates", [["2026-01-01", "2026-02-01"], [], ["2026-01-01"]])
+def test_ascending_accepts_ordered_dates(dates):
+    assert smoke.out_of_order(dates) is None
+
+
+def test_ascending_reports_the_pair_that_went_backwards():
+    problem = smoke.out_of_order(["2026-02-01", "2026-01-01"])
+    assert problem is not None
+    assert "2026-01-01" in problem

--- a/tests/test_tools_admin.py
+++ b/tests/test_tools_admin.py
@@ -1,0 +1,113 @@
+"""What the admin toolset says when Thunderbird is not attached.
+
+`tb_status` and `tb_diagnostics` are the two tools a model reaches for the moment
+anything else reports that it cannot reach Thunderbird, so their `hint` is the whole
+diagnosis as far as the model is concerned. It used to be one fixed sentence —
+"ask the user to start Thunderbird" — which was actively wrong on the morning the
+add-on was dialling in twice a minute and failing the handshake every time.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+from mcp import Client
+
+from tbmcp.config import Settings
+from tbmcp.server import build_server
+
+pytestmark = pytest.mark.anyio
+
+FAILING_HANDSHAKE = {
+    "attempts": 3,
+    "lastAttemptAt": time.time() - 5,
+    "lastOutcome": "no-upgrade",
+    "lastCloseCode": None,
+    "lastUserAgent": "Thunderbird/155.0",
+    "recentFailures": 3,
+    "recentOutcomes": {"no-upgrade": 3},
+    "windowSeconds": 60.0,
+    "recent": [],
+}
+
+QUIET_HANDSHAKE = {
+    "attempts": 0,
+    "lastAttemptAt": None,
+    "lastOutcome": None,
+    "lastCloseCode": None,
+    "lastUserAgent": None,
+    "recentFailures": 0,
+    "recentOutcomes": {},
+    "windowSeconds": 60.0,
+    "recent": [],
+}
+
+
+def _server(bridge):
+    return build_server(Settings().merged_with(toolsets=("admin",)), bridge=bridge)
+
+
+def _daemon_status(handshake: dict | None) -> dict:
+    return {
+        "daemon": {"pid": 1234, "uptimeSeconds": 60.0, "clients": 1},
+        "profile": {"path": "/profile", "name": "default"},
+        "thunderbird": None,
+        "connected": False,
+        "handshake": handshake,
+        "logFile": "/state/tbmcp/daemon.log",
+    }
+
+
+async def test_tb_status_explains_a_failing_handshake_rather_than_blaming_the_user(
+    fake_bridge,
+) -> None:
+    bridge = fake_bridge({"daemon.status": _daemon_status(FAILING_HANDSHAKE)})
+
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("tb_status", {})
+
+    payload = result.structured_content
+    assert payload["handshake"]["recentFailures"] == 3
+    assert "never completed the handshake" in payload["hint"]
+    assert "Ask the user to start Thunderbird" not in payload["hint"]
+
+
+async def test_tb_status_keeps_the_usual_hint_when_nothing_has_dialled_in(fake_bridge) -> None:
+    """No attempts is the ordinary "Thunderbird is closed" case, and the ordinary
+    advice is the right advice for it."""
+    bridge = fake_bridge({"daemon.status": _daemon_status(QUIET_HANDSHAKE)})
+
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("tb_status", {})
+
+    payload = result.structured_content
+    assert "Ask the user to start Thunderbird" in payload["hint"]
+    assert payload["handshake"] == QUIET_HANDSHAKE
+
+
+async def test_tb_status_survives_a_daemon_too_old_to_report_handshakes(fake_bridge) -> None:
+    bridge = fake_bridge({"daemon.status": _daemon_status(None)})
+
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("tb_status", {})
+
+    payload = result.structured_content
+    assert payload["handshake"] is None
+    assert "Ask the user to start Thunderbird" in payload["hint"]
+
+
+async def test_tb_diagnostics_carries_the_handshake_record_and_the_diagnosis(
+    fake_bridge,
+) -> None:
+    bridge = fake_bridge({"daemon.status": _daemon_status(FAILING_HANDSHAKE)})
+
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("tb_diagnostics", {})
+
+    payload = result.structured_content
+    assert payload["connected"] is False
+    assert payload["handshake"]["lastOutcome"] == "no-upgrade"
+    assert "never completed the handshake" in payload["hint"]
+    # The privileged half was never asked: there is nothing to ask it through.
+    assert bridge.methods() == ["daemon.status"]

--- a/tests/test_tools_mail.py
+++ b/tests/test_tools_mail.py
@@ -78,6 +78,39 @@ async def test_search_rejects_a_malformed_date(fake_bridge) -> None:
     assert "ISO-8601" in _text(result)
 
 
+async def test_search_echoes_the_scope_the_add_on_searched(fake_bridge) -> None:
+    """The answer says what it covered, so nobody has to enumerate folders to find out."""
+    scope = {"folderIds": ["account1://INBOX"], "accountIds": None, "includeSubFolders": True}
+    bridge = fake_bridge({"messages.query": {"messages": [MESSAGE], "scope": scope}})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("mail_search", {"subject": "Invoice"})
+    assert not result.is_error, _text(result)
+    assert result.structured_content["scope"] == scope
+
+
+async def test_search_passes_on_the_index_note(fake_bridge) -> None:
+    bridge = fake_bridge({"messages.query": {"messages": [], "indexNote": "indexing is off"}})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("mail_search", {"full_text": "invoice"})
+    assert not result.is_error, _text(result)
+    assert result.structured_content["indexNote"] == "indexing is off"
+
+
+async def test_search_reports_no_field_the_add_on_never_filled(fake_bridge) -> None:
+    """`searchedFolders` was such a field: always null, and a null reads to a model
+    as a fact about the mailbox rather than as a field nobody wrote."""
+    bridge = fake_bridge({"messages.query": {"messages": [MESSAGE]}})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("mail_search", {"subject": "Invoice"})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert "searchedFolders" not in payload
+    assert "scope" not in payload
+    assert "indexNote" not in payload
+    assert [key for key, value in payload.items() if value is None] == []
+
+
 async def test_delete_without_confirmation_is_refused(fake_bridge) -> None:
     bridge = fake_bridge()
     async with Client(_server(bridge)) as client:

--- a/tests/test_tools_search.py
+++ b/tests/test_tools_search.py
@@ -1,0 +1,148 @@
+"""The search toolset, end to end through an in-memory MCP client.
+
+Every assertion here is about a field: which one the add-on actually writes, and
+which ones must not appear at all. A `null` in a search result is not neutral —
+a model reads `"totalAvailable": null` as a fact about the mailbox rather than as
+a field nobody filled in.
+"""
+
+from __future__ import annotations
+
+import pytest
+from mcp import Client
+
+from tbmcp.config import Settings
+from tbmcp.server import build_server
+
+pytestmark = pytest.mark.anyio
+
+HIT = {
+    "id": 202,
+    "glodaId": 1234,
+    "headerMessageId": "<m1@example.invalid>",
+    "subject": "Invoice 2026-07",
+    "author": "Supplier <billing@example.com>",
+    "date": "2026-07-01T09:30:00.000Z",
+    "folderId": "account1://INBOX",
+    "folderUri": "imap://me@example.com/INBOX",
+    "conversationId": 77,
+    "score": 12,
+}
+
+
+def _server(bridge):
+    return build_server(Settings().merged_with(toolsets=("search",)), bridge=bridge)
+
+
+def _text(result) -> str:
+    return " ".join(getattr(block, "text", "") for block in result.content)
+
+
+def _nulls(payload: dict) -> list[str]:
+    return [key for key, value in payload.items() if value is None]
+
+
+def search_result(**overrides) -> dict:
+    """What the add-on answers `x.gloda.search` with."""
+    return {
+        "query": "invoice",
+        "hits": [HIT],
+        "matched": 1,
+        "retrieved": 75,
+        "truncated": False,
+        "indexEnabled": True,
+        **overrides,
+    }
+
+
+async def test_the_match_count_is_the_total_when_nothing_was_cut_off(fake_bridge) -> None:
+    bridge = fake_bridge({"x.gloda.search": search_result(matched=3)})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "invoice"})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert payload["totalAvailable"] == 3
+    assert payload["matched"] == 3
+    assert payload["retrieved"] == 75
+    assert payload["indexEnabled"] is True
+    assert _nulls(payload) == []
+
+
+async def test_a_truncated_retrieval_reports_no_total(fake_bridge) -> None:
+    """`matched` counts what the ranking saw, which is not a total of anything."""
+    bridge = fake_bridge({"x.gloda.search": search_result(matched=1000, truncated=True)})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "invoice"})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert "totalAvailable" not in payload
+    assert payload["truncated"] is True
+    assert payload["matched"] == 1000
+
+
+async def test_unmatchable_terms_and_a_note_reach_the_caller(fake_bridge) -> None:
+    bridge = fake_bridge(
+        {
+            "x.gloda.search": search_result(
+                hits=[], matched=0, unmatchableTerms=["2.0"], note="The index cannot match 2.0."
+            )
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "payments 2.0"})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert payload["unmatchableTerms"] == ["2.0"]
+    assert payload["note"] == "The index cannot match 2.0."
+
+
+async def test_nothing_unmatchable_means_no_such_key(fake_bridge) -> None:
+    bridge = fake_bridge({"x.gloda.search": search_result()})
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_global", {"query": "invoice"})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert "unmatchableTerms" not in payload
+    assert "note" not in payload
+    assert _nulls(payload) == []
+
+
+async def test_a_conversation_reports_its_size_and_who_was_in_it(fake_bridge) -> None:
+    bridge = fake_bridge(
+        {
+            "x.gloda.conversation": {
+                "conversationId": 77,
+                "subject": "Shipment",
+                "participants": ["Ada <ada@example.invalid>", "Bob <bob@example.invalid>"],
+                "messages": [HIT],
+                "total": 3,
+            }
+        }
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_conversation", {"message_id": 202})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert payload["totalAvailable"] == 3
+    assert payload["subject"] == "Shipment"
+    assert payload["participants"][0] == "Ada <ada@example.invalid>"
+    assert _nulls(payload) == []
+
+
+async def test_a_conversation_the_index_knows_little_about_carries_no_nulls(fake_bridge) -> None:
+    bridge = fake_bridge(
+        {"x.gloda.conversation": {"conversationId": 77, "messages": [], "total": 0}}
+    )
+    async with Client(_server(bridge)) as client:
+        result = await client.call_tool("search_conversation", {"header_message_id": "<m1@x>"})
+    assert not result.is_error, _text(result)
+
+    payload = result.structured_content
+    assert "subject" not in payload
+    assert "participants" not in payload
+    assert _nulls(payload) == []

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,4 +1,4 @@
-"""The three version strings drift apart the moment nothing checks them."""
+"""The four version strings drift apart the moment nothing checks them."""
 
 from __future__ import annotations
 
@@ -6,7 +6,7 @@ import json
 import pathlib
 import tomllib
 
-from tbmcp import server
+from tbmcp import bootstrap, server
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 EXPECTED = "1.3.0"
@@ -21,10 +21,12 @@ def _manifest_version() -> str:
     return json.loads((ROOT / "addon" / "manifest.json").read_text(encoding="utf-8"))["version"]
 
 
-def test_all_three_versions_agree():
+def test_all_four_versions_agree():
     assert _pyproject_version() == EXPECTED
     assert _manifest_version() == EXPECTED
     assert server._version() == EXPECTED
+    # The bootstrapper carries its own copy: it must run before the package imports.
+    assert bootstrap.VERSION == EXPECTED
 
 
 def test_fallback_matches_packaging(monkeypatch):

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,7 +9,7 @@ import tomllib
 from tbmcp import server
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
-EXPECTED = "1.2.1"
+EXPECTED = "1.3.0"
 
 
 def _pyproject_version() -> str:

--- a/tools/smoke_live.py
+++ b/tools/smoke_live.py
@@ -29,7 +29,7 @@ CHECKS: list[tuple[str, dict, str]] = [
     ("account_list", {}, "count"),
     ("folder_list", {}, "count"),
     ("mail_tags", {}, "count"),
-    ("search_index_status", {}, "indexerEnabled"),
+    ("search_index_status", {}, "enabled"),
     ("pref_get", {"name": "mail.pane_config.dynamic"}, "value"),
     ("pref_list", {"prefix": "mailnews.tags.", "only_user_set": True}, "count"),
     ("identity_list", {}, "count"),

--- a/tools/smoke_search.py
+++ b/tools/smoke_search.py
@@ -65,13 +65,18 @@ def common_term(messages: list[dict[str, Any]]) -> str | None:
     """
     counts: Counter[str] = Counter()
     seen_as: dict[str, str] = {}
+    first_seen: dict[str, int] = {}
     for message in messages:
-        words = {w for w in WORD.findall(message.get("subject") or "") if len(w) >= MIN_WORD}
-        for word in {w.lower() for w in words}:
+        # In subject order, so a tie between two words is settled by which one a
+        # reader met first — deterministic, unlike set iteration.
+        words = [w for w in WORD.findall(message.get("subject") or "") if len(w) >= MIN_WORD]
+        for word in dict.fromkeys(w.lower() for w in words):
             counts[word] += 1
+            first_seen.setdefault(word, len(first_seen))
         for word in words:
             seen_as.setdefault(word.lower(), word)
-    for word, n in counts.most_common():
+    ranked = sorted(counts.items(), key=lambda kv: (-kv[1], first_seen[kv[0]]))
+    for word, n in ranked:
         if n >= MIN_SHARED:
             return seen_as[word]
     return None

--- a/tools/smoke_search.py
+++ b/tools/smoke_search.py
@@ -1,0 +1,375 @@
+#!/usr/bin/env python3
+"""Live acceptance run for the search tools, against a running Thunderbird.
+
+    python tools/smoke_search.py
+
+Read-only: it searches, lists and reads, and changes nothing. It exists because
+the mocked suite cannot see the add-on, and every one of the 1.2.0 search defects
+passed a green run — this is the check that would have caught them. The corpus
+is discovered from whatever mail the profile has, so nothing here is tied to one
+mailbox; a check the corpus cannot support is skipped and says why.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import re
+import sys
+from collections import Counter
+from collections.abc import Callable
+from itertools import pairwise
+from typing import Any
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1] / "src"))
+
+from mcp import Client
+
+from tbmcp.config import Settings
+from tbmcp.server import build_server
+
+MIN_FOLDER = 20
+MIN_SHARED = 3
+MIN_WORD = 4
+WORD = re.compile(r"[A-Za-z0-9]+")
+
+
+# ------------------------------------------------------------------ pure parts
+
+
+def biggest_folder(folders: list[dict[str, Any]]) -> dict[str, Any] | None:
+    """The fullest real folder, or None when nothing holds MIN_FOLDER messages.
+
+    Saved searches are skipped: a virtual folder counts messages it does not hold
+    and cannot be paged like a real one.
+    """
+    best: dict[str, Any] | None = None
+    for folder in folders:
+        if folder.get("isVirtual") or folder.get("isRoot"):
+            continue
+        count = folder.get("totalMessageCount") or 0
+        if count < MIN_FOLDER:
+            continue
+        if best is None or count > (best.get("totalMessageCount") or 0):
+            best = folder
+    return best
+
+
+def common_term(messages: list[dict[str, Any]]) -> str | None:
+    """A word (>= MIN_WORD letters) that at least MIN_SHARED subjects share.
+
+    Case-insensitive when counting, but the spelling returned is one that was
+    actually seen: `subject` is a case-sensitive substring match on the far side,
+    so the live search has to ask for a string that exists. One subject counts
+    once however often it repeats the word.
+    """
+    counts: Counter[str] = Counter()
+    seen_as: dict[str, str] = {}
+    for message in messages:
+        words = {w for w in WORD.findall(message.get("subject") or "") if len(w) >= MIN_WORD}
+        for word in {w.lower() for w in words}:
+            counts[word] += 1
+        for word in words:
+            seen_as.setdefault(word.lower(), word)
+    for word, n in counts.most_common():
+        if n >= MIN_SHARED:
+            return seen_as[word]
+    return None
+
+
+def paging_gap(walked: list[int], straight: list[int]) -> str | None:
+    """Why a cursor walk differs from one straight call, or None when it matches."""
+    if walked == straight:
+        return None
+    missing = [i for i in straight if i not in walked]
+    invented = [i for i in walked if i not in straight]
+    if missing or invented:
+        parts = []
+        if missing:
+            parts.append(f"{len(missing)} missing ({missing[:6]})")
+        if invented:
+            parts.append(f"ids the walk invented: {invented[:6]}")
+        return "; ".join(parts)
+    return f"same ids in a different order: walked {walked[:6]}, straight {straight[:6]}"
+
+
+def invalid_folder_ids(items: list[dict[str, Any]], known: set[str] | None) -> list[str]:
+    """Items whose folderId is not one the profile knows (shape only without a list)."""
+    bad: list[str] = []
+    for item in items:
+        folder_id = item.get("folderId")
+        if not isinstance(folder_id, str) or ":/" not in folder_id:
+            bad.append(f"{folder_id!r} is not a folder id")
+        elif known is not None and folder_id not in known:
+            bad.append(f"{folder_id} is not a folder this profile lists")
+    return bad
+
+
+def out_of_order(dates: list[str | None]) -> str | None:
+    """The first pair of dates that goes backwards, or None when ascending."""
+    for earlier, later in pairwise(dates):
+        if earlier and later and later < earlier:
+            return f"{later} comes after {earlier}"
+    return None
+
+
+class Report:
+    """Prints one line per check and remembers which ones failed."""
+
+    def __init__(self) -> None:
+        self.failures: list[str] = []
+
+    def check(
+        self,
+        name: str,
+        result: Any,
+        summary: str = "",
+        *,
+        verify: Callable[[Any], str | None] | None = None,
+    ) -> Any:
+        """PASS/FAIL one call. Returns the payload on success, None on failure."""
+        if getattr(result, "is_error", False):
+            text = " ".join(getattr(block, "text", "") for block in result.content).strip()
+            print(f"  FAIL  {name:<34} {text[:160] or 'the tool returned an error'}")
+            self.failures.append(name)
+            return None
+        payload = result.structured_content
+        problem = verify(payload) if verify else None
+        if problem:
+            print(f"  FAIL  {name:<34} {problem[:160]}")
+            self.failures.append(name)
+            return None
+        print(f"  PASS  {name:<34} {summary}")
+        return payload
+
+    def skip(self, name: str, why: str) -> None:
+        print(f"  SKIP  {name:<34} {why}")
+
+
+# ------------------------------------------------------------------- live run
+
+
+def _error_text(result: Any) -> str:
+    return " ".join(getattr(block, "text", "") for block in result.content)
+
+
+async def _walk(call: Any, tool: str, args: dict[str, Any], step: int, pages: int) -> list[int]:
+    ids: list[int] = []
+    cursor = None
+    for _ in range(pages):
+        result = await call(tool, {**args, "limit": step, **({"cursor": cursor} if cursor else {})})
+        if result.is_error:
+            raise RuntimeError(_error_text(result))
+        ids += [m["id"] for m in result.structured_content["items"]]
+        cursor = result.structured_content.get("nextCursor")
+        if not cursor:
+            break
+    return ids
+
+
+async def main() -> int:
+    settings = Settings().merged_with(toolsets=("mail", "folders", "search", "admin"))
+    report = Report()
+    async with Client(build_server(settings)) as client:
+        call = client.call_tool
+
+        status = report.check(
+            "tb_status connected",
+            await call("tb_status", {}),
+            verify=lambda got: None if got.get("connected") else "Thunderbird is not attached",
+        )
+        if status is None:
+            return 1
+        print(
+            f"        add-on {status.get('addonVersion')}, {status.get('app', {}).get('version')}"
+        )
+
+        folders = (await call("folder_list", {"limit": 200})).structured_content["items"]
+        known = {f["id"] for f in folders}
+        folder = biggest_folder(folders)
+        if folder is None:
+            report.skip("corpus", f"no real folder holds {MIN_FOLDER}+ messages")
+            return 1 if report.failures else 0
+        listed = (
+            await call("mail_list", {"folder_id": folder["id"], "limit": 50})
+        ).structured_content
+        term = common_term(listed["items"])
+        print(
+            f"        corpus: {folder['id']} ({folder.get('totalMessageCount')} messages), term {term!r}\n"
+        )
+
+        # ---- substring search
+        if term is None:
+            report.skip("mail_search subject", "no word shared by three subjects")
+        else:
+            found = report.check(
+                "mail_search subject",
+                await call("mail_search", {"subject": term, "limit": 5}),
+                "matches",
+                verify=lambda got: (
+                    "no matches"
+                    if not got.get("count")
+                    else "; ".join(invalid_folder_ids(got["items"], known)) or None
+                ),
+            )
+            scoped = report.check(
+                "mail_search subject + folder",
+                await call("mail_search", {"subject": term, "folder_id": folder["id"], "limit": 5}),
+                "only that folder, scope reported",
+                verify=lambda got: (
+                    "no scope block"
+                    if not got.get("scope")
+                    else (
+                        "a hit outside the folder"
+                        if {m["folderId"] for m in got["items"]} - {folder["id"]}
+                        else None
+                    )
+                ),
+            )
+            del found, scoped
+
+        # ---- ranked search
+        ranked = None
+        if term is not None:
+            result = await call("search_global", {"query": term, "limit": 5})
+            if not result.is_error and not result.structured_content.get("count"):
+                report.skip("search_global ranked", f"the index has no hits for {term!r}")
+            else:
+                ranked = report.check(
+                    "search_global ranked",
+                    result,
+                    "score and date on every hit",
+                    verify=lambda got: (
+                        "a hit without score or date"
+                        if any(h.get("score") is None or not h.get("date") for h in got["items"])
+                        else None
+                    ),
+                )
+        if ranked:
+            hit = ranked["items"][0]
+            report.check(
+                "search_global folder scoped",
+                await call(
+                    "search_global", {"query": term, "limit": 20, "folder_id": hit["folderId"]}
+                ),
+                "only that folder",
+                verify=lambda got: (
+                    "a hit outside the folder"
+                    if {h["folderId"] for h in got["items"]} - {hit["folderId"]}
+                    else None
+                ),
+            )
+            thread = report.check(
+                "search_conversation by id",
+                await call("search_conversation", {"message_id": hit["id"]}),
+                "oldest first, participants named",
+                verify=lambda got: (
+                    out_of_order([m.get("date") for m in got["items"]])
+                    or (None if got.get("participants") else "no participants")
+                ),
+            )
+            if thread:
+                report.check(
+                    "search_conversation by header id",
+                    await call(
+                        "search_conversation", {"header_message_id": hit["headerMessageId"]}
+                    ),
+                    "same conversation",
+                    verify=lambda got: (
+                        None
+                        if got.get("conversationId") == thread.get("conversationId")
+                        else "a different conversation"
+                    ),
+                )
+
+        # ---- index and terms
+        report.check(
+            "search_index_status",
+            await call("search_index_status", {}),
+            "indexedMessages is a number",
+            verify=lambda got: (
+                None
+                if not got.get("enabled") or isinstance(got.get("indexedMessages"), int)
+                else f"indexedMessages is {got.get('indexedMessages')!r}"
+            ),
+        )
+        if term is not None:
+            report.check(
+                "search_global unmatchable term",
+                await call("search_global", {"query": f"{term} 2.0", "limit": 5}),
+                "names 2.0",
+                verify=lambda got: (
+                    None
+                    if got.get("unmatchableTerms") == ["2.0"]
+                    else f"unmatchableTerms={got.get('unmatchableTerms')!r}"
+                ),
+            )
+        bad = await call("search_global", {"query": "anything", "folder_id": "accountZZ://nope"})
+        text = _error_text(bad)
+        if bad.is_error and "accountZZ" in text and "unexpected error" not in text.lower():
+            print(f"  PASS  {'search_global bad folder id':<34} the error names the folder")
+        else:
+            print(f"  FAIL  {'search_global bad folder id':<34} {text[:160] or 'no error at all'}")
+            report.failures.append("search_global bad folder id")
+
+        # ---- paging conservation
+        straight = [
+            m["id"]
+            for m in (
+                await call("mail_list", {"folder_id": folder["id"], "limit": 12})
+            ).structured_content["items"]
+        ]
+        if len(straight) < 12:
+            report.skip("mail_list paging", "fewer than 12 messages")
+        else:
+            gap = paging_gap(
+                await _walk(call, "mail_list", {"folder_id": folder["id"]}, 3, 4), straight
+            )
+            _verdict(report, "mail_list paging 3x4 == 12", gap)
+        if term is not None:
+            straight = [
+                m["id"]
+                for m in (
+                    await call("mail_search", {"subject": term, "limit": 12})
+                ).structured_content["items"]
+            ]
+            if len(straight) < 12:
+                report.skip("mail_search paging", "fewer than 12 matches")
+            else:
+                gap = paging_gap(
+                    await _walk(call, "mail_search", {"subject": term}, 3, 4), straight
+                )
+                _verdict(report, "mail_search paging 3x4 == 12", gap)
+
+        # ---- a wide answer must not drop the connection
+        if term is not None:
+            wide = await call("search_global", {"query": term, "limit": 200})
+            after = (await call("tb_status", {})).structured_content
+            if wide.is_error or not after.get("connected"):
+                print(
+                    f"  FAIL  {'search_global wide answer':<34} {_error_text(wide)[:120] or 'the bridge dropped'}"
+                )
+                report.failures.append("search_global wide answer")
+            else:
+                print(
+                    f"  PASS  {'search_global wide answer':<34} {wide.structured_content.get('count')} hits, still connected"
+                )
+
+    print()
+    if report.failures:
+        print(f"{len(report.failures)} check(s) failed: {', '.join(report.failures)}")
+        return 1
+    print("every search check passed against the live Thunderbird")
+    return 0
+
+
+def _verdict(report: Report, name: str, gap: str | None) -> None:
+    if gap is None:
+        print(f"  PASS  {name:<34} same ids, same order")
+    else:
+        print(f"  FAIL  {name:<34} {gap}")
+        report.failures.append(name)
+
+
+if __name__ == "__main__":
+    raise SystemExit(asyncio.run(main()))

--- a/tools/smoke_search.py
+++ b/tools/smoke_search.py
@@ -192,19 +192,25 @@ async def main() -> int:
         folders = (await call("folder_list", {"limit": 200})).structured_content["items"]
         known = {f["id"] for f in folders}
         folder = biggest_folder(folders)
+        term = None
         if folder is None:
+            # Every check that needs a corpus is skipped one by one below, saying so;
+            # the ones that do not — index status, the bad folder id — still run.
             report.skip("corpus", f"no real folder holds {MIN_FOLDER}+ messages")
-            return 1 if report.failures else 0
-        listed = (
-            await call("mail_list", {"folder_id": folder["id"], "limit": 50})
-        ).structured_content
-        term = common_term(listed["items"])
-        print(
-            f"        corpus: {folder['id']} ({folder.get('totalMessageCount')} messages), term {term!r}\n"
-        )
+        else:
+            listed = (
+                await call("mail_list", {"folder_id": folder["id"], "limit": 50})
+            ).structured_content
+            term = common_term(listed["items"])
+            print(
+                f"        corpus: {folder['id']} ({folder.get('totalMessageCount')} messages), "
+                f"term {term!r}\n"
+            )
 
         # ---- substring search
-        if term is None:
+        if folder is None:
+            report.skip("mail_search subject", "no corpus")
+        elif term is None:
             report.skip("mail_search subject", "no word shared by three subjects")
         else:
             found = report.check(
@@ -298,7 +304,9 @@ async def main() -> int:
                 else f"indexedMessages is {got.get('indexedMessages')!r}"
             ),
         )
-        if term is not None:
+        if term is None:
+            report.skip("search_global unmatchable term", "no term")
+        else:
             report.check(
                 "search_global unmatchable term",
                 await call("search_global", {"query": f"{term} 2.0", "limit": 5}),
@@ -318,20 +326,25 @@ async def main() -> int:
             report.failures.append("search_global bad folder id")
 
         # ---- paging conservation
-        straight = [
-            m["id"]
-            for m in (
-                await call("mail_list", {"folder_id": folder["id"], "limit": 12})
-            ).structured_content["items"]
-        ]
-        if len(straight) < 12:
-            report.skip("mail_list paging", "fewer than 12 messages")
+        if folder is None:
+            report.skip("mail_list paging", "no corpus")
         else:
-            gap = paging_gap(
-                await _walk(call, "mail_list", {"folder_id": folder["id"]}, 3, 4), straight
-            )
-            _verdict(report, "mail_list paging 3x4 == 12", gap)
-        if term is not None:
+            straight = [
+                m["id"]
+                for m in (
+                    await call("mail_list", {"folder_id": folder["id"], "limit": 12})
+                ).structured_content["items"]
+            ]
+            if len(straight) < 12:
+                report.skip("mail_list paging", "fewer than 12 messages")
+            else:
+                gap = paging_gap(
+                    await _walk(call, "mail_list", {"folder_id": folder["id"]}, 3, 4), straight
+                )
+                _verdict(report, "mail_list paging 3x4 == 12", gap)
+        if term is None:
+            report.skip("mail_search paging", "no term")
+        else:
             straight = [
                 m["id"]
                 for m in (
@@ -347,7 +360,9 @@ async def main() -> int:
                 _verdict(report, "mail_search paging 3x4 == 12", gap)
 
         # ---- a wide answer must not drop the connection
-        if term is not None:
+        if term is None:
+            report.skip("search_global wide answer", "no term")
+        else:
             wide = await call("search_global", {"query": term, "limit": 200})
             after = (await call("tb_status", {})).structured_content
             if wide.is_error or not after.get("connected"):


### PR DESCRIPTION
Every search tool in 1.2.0 was broken (six independent defects, reported in #3), and the bridge could fail in a way nothing reported. This branch fixes both, adds a test layer that can see the add-on, and is verified live against Thunderbird 155.

## Fixed
- `mail_search` returned nothing (`returnMessageListId` turns the answer into a bare string, which was then walked).
- `search_global`/`search_conversation` failed with "An unexpected error occurred" (no `setTimeout` in the privileged sandbox; deadlines rejected before the work began). Also restored `indexedMessages` and the calendar/filter/junk deadlines.
- Hits had `date: null` and threads were unordered (cross-realm `instanceof Date`).
- Folder-scoped global search matched nothing (folder id mistaken for a URI, off-by-one slice).
- A term the index cannot tokenise (`2.0`) zeroed the query silently — now named in `unmatchableTerms`.
- Privileged errors crossed the boundary as a generic string with a spurious `[Error]` tag — every privileged method now uses a `tbxerr:` envelope the background page unpacks.
- Paging skipped the rest of a page (`mail_list(limit=3)` + cursor skipped 97 of 100 messages) — remainders are parked behind `tbx:<load>:<n>` cursors; stale cursors are refused.
- Doubled error tags; `mcp` ≥ 2.1 dropping error text (`ToolError`); a ~64 KB answer dropping the bridge (stream limit, typed `TOO_LARGE`, read-loop invalidation).
- Fields Python read but nothing wrote (`searchedFolders`, `totalMatched`, `participants`).
- A superseded daemon deleting the winner's files; `install-addon` leaving Thunderbird closed; an unknown `messages.tags` permission in the manifest.

## Added
- Handshake telemetry: the daemon records what became of every add-on connection; `tb_status`, `tb_diagnostics` and `doctor` report recent failures with the remedy. A daemon log file. `doctor` warns when the installed add-on is older than the package.
- Add-on transport hardening: synchronous hello, handshake/connect/pairing watchdogs, backoff, visible state in `tbmcp-addon-status.json`.
- `tb_console` includes the add-on's own `[tbmcp]` lines.
- A node test layer for the add-on (`tests/js`, 111 tests, in CI), `tools/smoke_search.py` (live acceptance), CI on Python 3.14.

## Changed payloads
`mail_search` → `scope` (replaces `searchedFolders`); `search_global` → `matched`/`retrieved`/`truncated`/`unmatchableTerms`, `totalAvailable` only when complete; `search_conversation` → `participants`/`totalAvailable`; no `null` keys for unset fields. See CHANGELOG.md.

## Verification
pytest 287, node 111, ruff, `check_consistency.py`, `build_xpi.py`, docs in sync. Live on Thunderbird 155.0 with the 1.3.0 add-on: `tools/smoke_search.py` 13/13, `tools/smoke_live.py` 17/17; a 154-hit search arrives with the bridge still up; a replaced daemon is re-attached by the add-on in 3 s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXUPrPuoxvcXZn9RDCxRKE
